### PR TITLE
fw: do not validate packets after parse

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 on:
   push:
+    branches: ["main"]
   pull_request:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: test
 on:
   push:
+    branches: ["main"]
   pull_request:
 
 jobs:

--- a/fw/face/ndnlp-link-service.go
+++ b/fw/face/ndnlp-link-service.go
@@ -296,7 +296,7 @@ func (l *NDNLPLinkService) handleIncomingFrame(frame []byte) {
 		IncomingFaceID: utils.IdPtr(l.faceID),
 	}
 
-	L2, _, err := spec.ReadPacket(enc.NewBufferReader(wire))
+	L2, err := ReadPacketUnverified(enc.NewBufferReader(wire))
 	if err != nil {
 		core.LogError(l, err)
 		return
@@ -370,7 +370,7 @@ func (l *NDNLPLinkService) handleIncomingFrame(frame []byte) {
 		}
 
 		// Parse inner packet in place
-		L3, _, err := spec.ReadPacket(enc.NewBufferReader(wire))
+		L3, err := ReadPacketUnverified(enc.NewBufferReader(wire))
 		if err != nil {
 			return
 		}
@@ -441,4 +441,11 @@ func (op *NDNLPLinkServiceOptions) Flags() (ret uint64) {
 		ret |= FaceFlagCongestionMarking
 	}
 	return
+}
+
+// Reads a packet without validating the internal fields
+func ReadPacketUnverified(reader enc.ParseReader) (*spec.Packet, error) {
+	context := spec.PacketParsingContext{}
+	context.Init()
+	return context.Parse(reader, false)
 }


### PR DESCRIPTION
spec.ReadPacket validates the digest on Interests if app params are present. This is unnecessary for forwarding.