### PR TITLE
Add encoding.Name.Append() method

### DIFF
--- a/dv/config/config.go
+++ b/dv/config/config.go
@@ -79,29 +79,29 @@ func (c *Config) Parse() (err error) {
 	}
 
 	// Create name table
-	c.advSyncPfxN = append(enc.Name{enc.LOCALHOP}, append(c.networkNameN,
+	c.advSyncPfxN = enc.LOCALHOP.Append(c.networkNameN.Append(
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"),
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "ADS"),
 	)...)
-	c.advSyncActivePfxN = append(c.advSyncPfxN,
+	c.advSyncActivePfxN = c.advSyncPfxN.Append(
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "ACT"),
 	)
-	c.advSyncPassivePfxN = append(c.advSyncPfxN,
+	c.advSyncPassivePfxN = c.advSyncPfxN.Append(
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "PSV"),
 	)
-	c.advDataPfxN = append(enc.Name{enc.LOCALHOP}, append(c.routerNameN,
+	c.advDataPfxN = enc.LOCALHOP.Append(c.routerNameN.Append(
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"),
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "ADV"),
 	)...)
-	c.pfxSyncPfxN = append(c.networkNameN,
+	c.pfxSyncPfxN = c.networkNameN.Append(
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"),
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "PFS"),
 	)
-	c.pfxDataPfxN = append(c.routerNameN,
+	c.pfxDataPfxN = c.routerNameN.Append(
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"),
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "PFX"),
 	)
-	c.localPfxN = append(enc.Name{enc.LOCALHOST},
+	c.localPfxN = enc.LOCALHOST.Append(
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "nlsr"),
 	)
 
@@ -145,13 +145,13 @@ func (c *Config) LocalPrefix() enc.Name {
 }
 
 func (c *Config) ReadvertisePrefix() enc.Name {
-	return append(c.localPfxN,
+	return c.localPfxN.Append(
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "rib"),
 	)
 }
 
 func (c *Config) StatusPrefix() enc.Name {
-	return append(c.localPfxN,
+	return c.localPfxN.Append(
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "status"),
 	)
 }

--- a/dv/dv/advert_data.go
+++ b/dv/dv/advert_data.go
@@ -43,7 +43,7 @@ func (dv *Router) advertDataFetch(nodeId enc.Name, seqNo uint64) {
 	}
 
 	// Fetch the advertisement
-	advName := append(enc.Name{enc.LOCALHOP}, append(nodeId,
+	advName := enc.LOCALHOP.Append(nodeId.Append(
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"),
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "ADV"),
 		enc.NewVersionComponent(seqNo),

--- a/dv/dv/advert_sync.go
+++ b/dv/dv/advert_sync.go
@@ -29,7 +29,7 @@ func (dv *Router) advertSyncSendInterest() (err error) {
 
 func (dv *Router) advertSyncSendInterestImpl(prefix enc.Name) (err error) {
 	// SVS v2 Sync Interest
-	syncName := append(prefix, enc.NewVersionComponent(2))
+	syncName := prefix.Append(enc.NewVersionComponent(2))
 
 	// Sync Interest parameters for SVS
 	cfg := &ndn.InterestConfig{

--- a/dv/dv/table_algo.go
+++ b/dv/dv/table_algo.go
@@ -117,9 +117,7 @@ func (dv *Router) fibUpdate() {
 		fes := dv.rib.GetFibEntries(dv.neighbors, router.Name().Hash())
 
 		// Add entry to the router itself
-		routerPrefix := append(router.Name(),
-			enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"),
-		)
+		routerPrefix := router.Name().Append(enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"))
 		register(routerPrefix, fes)
 
 		// Add entries to all prefixes announced by this router

--- a/dv/table/neighbor_table.go
+++ b/dv/table/neighbor_table.go
@@ -127,7 +127,7 @@ func (ns *NeighborState) delete() {
 }
 
 func (ns *NeighborState) localRoute() enc.Name {
-	return append(enc.Name{enc.LOCALHOP}, append(ns.Name,
+	return enc.LOCALHOP.Append(ns.Name.Append(
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"),
 	)...)
 }

--- a/dv/table/prefix_table.go
+++ b/dv/table/prefix_table.go
@@ -152,7 +152,7 @@ func (pt *PrefixTable) Apply(ops *tlv.PrefixOpList) (dirty bool) {
 // If the difference between Known and Latest is greater than the threshold,
 // fetch the latest snapshot. Otherwise, fetch the next sequence number.
 func (r *PrefixTableRouter) GetNextDataName() enc.Name {
-	name := append(r.Name,
+	name := r.Name.Append(
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"),
 		enc.NewStringComponent(enc.TypeKeywordNameComponent, "PFX"),
 	)
@@ -206,7 +206,7 @@ func (pt *PrefixTable) publishOp(content enc.Wire) {
 
 	// Produce the operation
 	name, err := pt.client.Produce(object.ProduceArgs{
-		Name:    append(pt.config.PrefixTableDataPrefix(), enc.NewSequenceNumComponent(seq)),
+		Name:    pt.config.PrefixTableDataPrefix().Append(enc.NewSequenceNumComponent(seq)),
 		Content: content,
 		Version: utils.IdPtr(uint64(0)), // immutable
 	})
@@ -239,7 +239,7 @@ func (pt *PrefixTable) publishSnap() {
 
 	// Produce the snapshot
 	name, err := pt.client.Produce(object.ProduceArgs{
-		Name:    append(pt.config.PrefixTableDataPrefix(), PREFIX_SNAP_COMP),
+		Name:    pt.config.PrefixTableDataPrefix().Append(PREFIX_SNAP_COMP),
 		Content: snap.Encode(),
 		Version: utils.IdPtr(pt.me.Latest),
 	})

--- a/fw/defn/name.go
+++ b/fw/defn/name.go
@@ -9,9 +9,9 @@ var LOCAL_PREFIX = enc.Name{enc.LOCALHOST, enc.NewStringComponent(enc.TypeGeneri
 var NON_LOCAL_PREFIX = enc.Name{enc.LOCALHOP, enc.NewStringComponent(enc.TypeGenericNameComponent, "nfd")}
 
 // Prefix for all stratgies
-var STRATEGY_PREFIX = append(LOCAL_PREFIX, enc.NewStringComponent(enc.TypeGenericNameComponent, "strategy"))
+var STRATEGY_PREFIX = LOCAL_PREFIX.Append(enc.NewStringComponent(enc.TypeGenericNameComponent, "strategy"))
 
 // Default forwarding strategy name
-var DEFAULT_STRATEGY = append(STRATEGY_PREFIX,
+var DEFAULT_STRATEGY = STRATEGY_PREFIX.Append(
 	enc.NewStringComponent(enc.TypeGenericNameComponent, "best-route"),
 	enc.NewVersionComponent(1))

--- a/fw/fw/strategy.go
+++ b/fw/fw/strategy.go
@@ -59,7 +59,7 @@ func (s *StrategyBase) NewStrategyBase(
 	s.thread = fwThread
 	s.threadID = s.thread.threadID
 	s.strategyName = strategyName
-	s.name = append(defn.STRATEGY_PREFIX, strategyName, enc.NewVersionComponent(version))
+	s.name = defn.STRATEGY_PREFIX.Append(strategyName, enc.NewVersionComponent(version))
 	s.version = version
 	s.strategyLogName = strategyLogName
 }

--- a/fw/mgmt/cs.go
+++ b/fw/mgmt/cs.go
@@ -122,7 +122,7 @@ func (c *ContentStoreModule) info(interest *Interest) {
 		status.CsInfo.NCsEntries += uint64(thread.GetNumCsEntries())
 	}
 
-	name := append(LOCAL_PREFIX,
+	name := LOCAL_PREFIX.Append(
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "cs"),
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "info"),
 	)

--- a/fw/mgmt/face.go
+++ b/fw/mgmt/face.go
@@ -472,7 +472,7 @@ func (f *FaceModule) list(interest *Interest) {
 		dataset.Vals = append(dataset.Vals, f.createDataset(faces[pos]))
 	}
 
-	name := append(LOCAL_PREFIX,
+	name := LOCAL_PREFIX.Append(
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "faces"),
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "list"),
 	)

--- a/fw/mgmt/fib.go
+++ b/fw/mgmt/fib.go
@@ -153,7 +153,7 @@ func (f *FIBModule) list(interest *Interest) {
 		dataset.Entries = append(dataset.Entries, fibEntry)
 	}
 
-	name := append(LOCAL_PREFIX,
+	name := LOCAL_PREFIX.Append(
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "fib"),
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "list"),
 	)

--- a/fw/mgmt/forwarder-status.go
+++ b/fw/mgmt/forwarder-status.go
@@ -79,7 +79,7 @@ func (f *ForwarderStatusModule) general(interest *Interest) {
 		status.NUnsatisfiedInterests += thread.(*fw.Thread).NUnsatisfiedInterests
 	}
 
-	name := append(LOCAL_PREFIX,
+	name := LOCAL_PREFIX.Append(
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "status"),
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "general"),
 	)

--- a/fw/mgmt/helpers.go
+++ b/fw/mgmt/helpers.go
@@ -8,15 +8,9 @@
 package mgmt
 
 import (
-	"time"
-
 	"github.com/named-data/ndnd/fw/core"
 	enc "github.com/named-data/ndnd/std/encoding"
-	"github.com/named-data/ndnd/std/ndn"
 	mgmt "github.com/named-data/ndnd/std/ndn/mgmt_2022"
-	spec "github.com/named-data/ndnd/std/ndn/spec_2022"
-	sec "github.com/named-data/ndnd/std/security"
-	"github.com/named-data/ndnd/std/utils"
 )
 
 func decodeControlParameters(m Module, interest *Interest) *mgmt.ControlArgs {
@@ -27,31 +21,4 @@ func decodeControlParameters(m Module, interest *Interest) *mgmt.ControlArgs {
 		return nil
 	}
 	return params.Val
-}
-
-// makeStatusDataset creates a set of status dataset packets based upon the specified prefix, version,
-// and dataset information.
-// Note: The old mgmt.MakeStatusDataset is clearly wrong as it is against the single-Interest-single-Data
-// principle. Thus, we simply assume that the data packet should always fit in one segment.
-func makeStatusDataset(name enc.Name, version uint64, dataset enc.Wire) enc.Wire {
-	// TODO: Split into 8000 byte segments and publish
-	if dataset.Length() > 8000 {
-		core.LogError("mgmt", "Status dataset is too large")
-		return nil
-	}
-	name = append(name, enc.NewVersionComponent(version), enc.NewSegmentComponent(0))
-	data, err := spec.Spec{}.MakeData(name,
-		&ndn.DataConfig{
-			ContentType:  utils.IdPtr(ndn.ContentTypeBlob),
-			Freshness:    utils.IdPtr(time.Second),
-			FinalBlockID: utils.IdPtr(enc.NewSegmentComponent(0)),
-		},
-		dataset,
-		sec.NewSha256Signer(),
-	)
-	if err != nil {
-		core.LogError("mgmt", "Unable to encode status dataset")
-		return nil
-	}
-	return data.Wire
 }

--- a/fw/mgmt/rib.go
+++ b/fw/mgmt/rib.go
@@ -218,8 +218,7 @@ func (r *RIBModule) list(interest *Interest) {
 		dataset.Entries = append(dataset.Entries, ribEntry)
 	}
 
-	name := append(
-		interest.Name()[:len(LOCAL_PREFIX)],
+	name := interest.Name()[:len(LOCAL_PREFIX)].Append(
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "rib"),
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "list"),
 	)

--- a/fw/mgmt/strategy-choice.go
+++ b/fw/mgmt/strategy-choice.go
@@ -123,7 +123,7 @@ func (s *StrategyChoiceModule) set(interest *Interest) {
 		}
 	} else {
 		// Add missing version information to strategy name
-		params.Strategy.Name = append(params.Strategy.Name, enc.NewVersionComponent(strategyVersion))
+		params.Strategy.Name = params.Strategy.Name.Append(enc.NewVersionComponent(strategyVersion))
 	}
 	table.FibStrategyTable.SetStrategyEnc(params.Name, params.Strategy.Name)
 
@@ -181,7 +181,7 @@ func (s *StrategyChoiceModule) list(interest *Interest) {
 	}
 	dataset := &mgmt.StrategyChoiceMsg{StrategyChoices: choices}
 
-	name := append(LOCAL_PREFIX,
+	name := LOCAL_PREFIX.Append(
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "strategy-choice"),
 		enc.NewStringComponent(enc.TypeGenericNameComponent, "list"),
 	)

--- a/fw/mgmt/thread.go
+++ b/fw/mgmt/thread.go
@@ -229,7 +229,7 @@ func (m *Thread) sendStatusDataset(interest *Interest, name enc.Name, dataset en
 	}
 
 	// Get first segment from object name
-	segment, err := m.store.Get(append(objName, enc.NewSegmentComponent(0)), false)
+	segment, err := m.store.Get(objName.Append(enc.NewSegmentComponent(0)), false)
 	if err != nil || segment == nil {
 		core.LogWarn(m, "Unable to get first segment of status dataset: ", err)
 		return

--- a/std/encoding/name_component.go
+++ b/std/encoding/name_component.go
@@ -361,6 +361,10 @@ func (c Component) CanonicalString() string {
 	return tName + compValFmtText{}.ToString(c.Val)
 }
 
+func (c Component) Append(rest ...Component) Name {
+	return Name{c}.Append(rest...)
+}
+
 func ParseComponent(buf Buffer) (Component, int) {
 	typ, p1 := ParseTLNum(buf)
 	l, p2 := ParseTLNum(buf[p1:])

--- a/std/encoding/name_pattern.go
+++ b/std/encoding/name_pattern.go
@@ -125,6 +125,7 @@ func (n Name) PrefixHash() []uint64 {
 	return ret
 }
 
+// NameFromStr parses a URI string into a Name
 func NameFromStr(s string) (Name, error) {
 	strs := strings.Split(s, "/")
 	// Removing leading and trailing empty strings given by /
@@ -144,6 +145,7 @@ func NameFromStr(s string) (Name, error) {
 	return ret, nil
 }
 
+// NamePatternFromStr parses a string into a NamePattern
 func NamePatternFromStr(s string) (NamePattern, error) {
 	strs := strings.Split(s, "/")
 	// Removing leading and trailing empty strings given by /
@@ -164,6 +166,7 @@ func NamePatternFromStr(s string) (NamePattern, error) {
 	return ret, nil
 }
 
+// NameFromBytes parses a URI byte slice into a Name
 func NameFromBytes(buf []byte) (Name, error) {
 	r := NewBufferReader(buf)
 	t, err := ReadTLNum(r)
@@ -187,6 +190,19 @@ func NameFromBytes(buf []byte) (Name, error) {
 		return nil, ErrFormat{"encoding.NameFromBytes: given bytes have a wrong length"}
 	}
 	return ret, nil
+}
+
+// Append appends one or more components to a name in a new memory space.
+// Calls to Append() should not be chained since these are relatively expensive.
+// Instead, specify all components to be appended in a single call.
+//
+// Note: this does *not* copy the underlying components, so direct changes to the
+// components will affect the returned Name.
+func (n Name) Append(rest ...Component) Name {
+	ret := make(Name, len(n)+len(rest))
+	copy(ret, n)
+	copy(ret[len(n):], rest)
+	return ret
 }
 
 func (n Name) Compare(rhs Name) int {
@@ -296,9 +312,8 @@ func (n Name) ToFullName(rawData Wire) Name {
 		h.Write(buf)
 	}
 	digest := h.Sum(nil)
-	ret := append(n, Component{
+	return n.Append(Component{
 		Typ: TypeImplicitSha256DigestComponent,
 		Val: digest,
 	})
-	return ret
 }

--- a/std/encoding/name_pattern.go
+++ b/std/encoding/name_pattern.go
@@ -192,12 +192,8 @@ func NameFromBytes(buf []byte) (Name, error) {
 	return ret, nil
 }
 
-// Append appends one or more components to a name in a new memory space.
-// Calls to Append() should not be chained since these are relatively expensive.
-// Instead, specify all components to be appended in a single call.
-//
-// Note: this does *not* copy the underlying components, so direct changes to the
-// components will affect the returned Name.
+// Append appends one or more components to a shallow copy of the name.
+// Using this function is recommended over the in-built `append`.
 func (n Name) Append(rest ...Component) Name {
 	ret := make(Name, len(n)+len(rest))
 	copy(ret, n)

--- a/std/examples/low-level/consumer/main.go
+++ b/std/examples/low-level/consumer/main.go
@@ -24,7 +24,7 @@ func main() {
 	defer app.Stop()
 
 	name, _ := enc.NameFromStr("/example/testApp/randomData")
-	name = append(name, enc.NewTimestampComponent(utils.MakeTimestamp(time.Now())))
+	name = name.Append(enc.NewTimestampComponent(utils.MakeTimestamp(time.Now())))
 
 	intCfg := &ndn.InterestConfig{
 		MustBeFresh: true,

--- a/std/examples/wasm/low-level/consumer/main.go
+++ b/std/examples/wasm/low-level/consumer/main.go
@@ -32,10 +32,10 @@ func main() {
 		logger.Errorf("Unable to start engine: %+v", err)
 		return
 	}
-	defer app.Shutdown()
+	defer app.Stop()
 
 	name, _ := enc.NameFromStr("/example/testApp/randomData")
-	name = append(name, enc.NewTimestampComponent(utils.MakeTimestamp(timer.Now())))
+	name = name.Append(enc.NewTimestampComponent(utils.MakeTimestamp(timer.Now())))
 
 	intCfg := &ndn.InterestConfig{
 		MustBeFresh: true,

--- a/std/ndn/mgmt_2022/mgmt.go
+++ b/std/ndn/mgmt_2022/mgmt.go
@@ -23,9 +23,9 @@ func (mgmt *MgmtConfig) MakeCmd(module string, cmd string,
 
 	var name enc.Name
 	if mgmt.local {
-		name = append(name, enc.LOCALHOST)
+		name = enc.Name{enc.LOCALHOST}
 	} else {
-		name = append(name, enc.LOCALHOP)
+		name = enc.Name{enc.LOCALHOP}
 	}
 
 	name = append(name,

--- a/std/object/client_consume.go
+++ b/std/object/client_consume.go
@@ -144,7 +144,7 @@ func (c *Client) fetchMetadata(
 ) {
 	log.Debugf("consume: fetching object metadata %s", name)
 	args := ExpressRArgs{
-		Name: append(name, rdr.METADATA),
+		Name: name.Append(rdr.METADATA),
 		Config: &ndn.InterestConfig{
 			CanBePrefix: true,
 			MustBeFresh: true,

--- a/std/object/client_consume_seg.go
+++ b/std/object/client_consume_seg.go
@@ -122,9 +122,7 @@ func (s *rrSegFetcher) doCheck() {
 
 	// queue outgoing interest for the next segment
 	args := ExpressRArgs{
-		Name: append(state.fetchName,
-			enc.NewSegmentComponent(seg),
-		),
+		Name: state.fetchName.Append(enc.NewSegmentComponent(seg)),
 		Config: &ndn.InterestConfig{
 			MustBeFresh: false,
 		},

--- a/std/object/client_produce.go
+++ b/std/object/client_produce.go
@@ -61,7 +61,7 @@ func Produce(args ProduceArgs, store ndn.Store, signer ndn.Signer) (enc.Name, er
 		FinalBlockID: &finalBlockId,
 	}
 
-	basename := append(args.Name.Clone(), enc.NewVersionComponent(version))
+	basename := args.Name.Append(enc.NewVersionComponent(version))
 
 	// use a transaction to ensure the entire object is written
 	store.Begin()
@@ -69,7 +69,7 @@ func Produce(args ProduceArgs, store ndn.Store, signer ndn.Signer) (enc.Name, er
 
 	var seg uint64
 	for seg = 0; seg <= lastSeg; seg++ {
-		name := append(basename.Clone(), enc.NewSegmentComponent(seg))
+		name := basename.Append(enc.NewSegmentComponent(seg))
 
 		segContent := enc.Wire{}
 		segContentSize := 0
@@ -106,7 +106,7 @@ func Produce(args ProduceArgs, store ndn.Store, signer ndn.Signer) (enc.Name, er
 
 	if !args.NoMetadata {
 		// write metadata packet
-		name := append(args.Name.Clone(),
+		name := args.Name.Append(
 			rdr.METADATA,
 			enc.NewVersionComponent(version),
 			enc.NewSegmentComponent(0),
@@ -158,7 +158,7 @@ func (c *Client) Remove(name enc.Name) error {
 	// Remove RDR metadata if we have a version
 	// If there is no version, we removed this anyway in the previous step
 	if version := name[len(name)-1]; version.Typ == enc.TypeVersionNameComponent {
-		err = c.store.Remove(append(name[:len(name)-1], rdr.METADATA, version), true)
+		err = c.store.Remove(name[:len(name)-1].Append(rdr.METADATA, version), true)
 		if err != nil {
 			return err
 		}

--- a/std/sync/svs.go
+++ b/std/sync/svs.go
@@ -289,7 +289,7 @@ func (s *SvSync) sendSyncInterest() {
 	}()
 
 	// SVS v2 Sync Interest
-	syncName := append(s.groupPrefix, enc.NewVersionComponent(2))
+	syncName := s.groupPrefix.Append(enc.NewVersionComponent(2))
 
 	// Sync Interest parameters for SVS
 	cfg := &ndn.InterestConfig{

--- a/tools/dvc/dvc.go
+++ b/tools/dvc/dvc.go
@@ -64,13 +64,11 @@ func RunDvLinkCreate(nfdcTree *utils.CmdTree) func([]string) {
 		status := dvGetStatus() // will panic if fail
 
 		// /localhop/<network>/32=DV/32=ADS/32=ACT
-		name := enc.Name{enc.NewStringComponent(enc.TypeGenericNameComponent, "localhop")}
-		name = append(name, status.NetworkName.Name...)
-		name = append(name,
+		name := enc.LOCALHOP.Append(status.NetworkName.Name.Append(
 			enc.NewStringComponent(enc.TypeKeywordNameComponent, "DV"),
 			enc.NewStringComponent(enc.TypeKeywordNameComponent, "ADS"),
 			enc.NewStringComponent(enc.TypeKeywordNameComponent, "ACT"),
-		)
+		)...)
 
 		nfdcTree.Execute([]string{
 			"nfdc", "route", "add",

--- a/tools/nfdc/nfdc_dataset.go
+++ b/tools/nfdc/nfdc_dataset.go
@@ -11,7 +11,7 @@ import (
 
 func (n *Nfdc) fetchStatusDataset(suffix enc.Name) (enc.Wire, error) {
 	// TODO: segmented fetch once supported by fw/mgmt
-	name := append(n.GetPrefix(), suffix...)
+	name := n.GetPrefix().Append(suffix...)
 	config := &ndn.InterestConfig{
 		MustBeFresh: true,
 		CanBePrefix: true,

--- a/tools/pingclient.go
+++ b/tools/pingclient.go
@@ -55,7 +55,7 @@ func (pc *PingClient) usage() {
 }
 
 func (pc *PingClient) send(seq uint64) {
-	name := append(pc.name, enc.NewSequenceNumComponent(seq))
+	name := pc.name.Append(enc.NewSequenceNumComponent(seq))
 
 	cfg := &ndn.InterestConfig{
 		Lifetime: utils.IdPtr(time.Duration(pc.timeout) * time.Millisecond),
@@ -148,8 +148,7 @@ func (pc *PingClient) run() {
 		log.Fatalf("Invalid prefix: %s", pc.args[1])
 	}
 	pc.prefix = prefixN
-	pc.name = append(prefixN,
-		enc.NewStringComponent(enc.TypeGenericNameComponent, "ping"))
+	pc.name = prefixN.Append(enc.NewStringComponent(enc.TypeGenericNameComponent, "ping"))
 
 	// initialize sequence number
 	if pc.seq == 0 {

--- a/tools/pingserver.go
+++ b/tools/pingserver.go
@@ -48,8 +48,7 @@ func (ps *PingServer) run() {
 	if err != nil {
 		log.Fatalf("Invalid prefix: %s", ps.args[1])
 	}
-	ps.name = append(prefix,
-		enc.NewStringComponent(enc.TypeGenericNameComponent, "ping"))
+	ps.name = prefix.Append(enc.NewStringComponent(enc.TypeGenericNameComponent, "ping"))
 
 	ps.app = engine.NewBasicEngine(engine.NewDefaultFace())
 	err = ps.app.Start()


### PR DESCRIPTION
append() has some unintuitive behavior due to sharing the underlying array. See the test in the first commit linked below for details:
https://github.com/named-data/ndnd/commit/9ce47e1e3f12d0f73e2617ecf6e1150427398dac#diff-7f7479b24b8bf1c99ac3258e8da6430d23fb052a4e26653d44128913e88cc4a2R338-R346

```golang
// This section illustrates the issue with using append()
// If we have a prefix which has an underlying array larger than the slice itself,
// then subsequent appends will modify the same array. This will overwrite any
// names created from the same prefix.
prefix := utils.WithoutErr(enc.NameFromStr("/a/b/c/z/z/z"))[:3]
name1 := append(prefix, utils.WithoutErr(enc.NameFromStr("d1/e1/f1"))...)
name2 := append(prefix, utils.WithoutErr(enc.NameFromStr("d2/e2/f2"))...)
require.Equal(t, name1.String(), name2.String()) // should not be equal
```

The second commit adapts the implementation to the new safe `name.Append()` method.

This is well described in https://go.dev/blog/slices-intro