### PR TITLE
std: util to encode TLV to string

### DIFF
--- a/std/encoding/component.go
+++ b/std/encoding/component.go
@@ -2,7 +2,6 @@ package encoding
 
 import (
 	"bytes"
-	"encoding/binary"
 	"hash"
 	"io"
 	"strconv"
@@ -159,16 +158,8 @@ func (c Component) Hash() uint64 {
 	h := hashPool.Get().(hash.Hash64)
 	defer hashPool.Put(h)
 	h.Reset()
-	c.HashInto(h)
+	h.Write(c.Bytes())
 	return h.Sum64()
-}
-
-// HashInto hashes the current component into the hasher
-func (c Component) HashInto(h hash.Hash) {
-	tbuf := []byte{0, 0, 0, 0, 0, 0, 0, 0}
-	binary.BigEndian.PutUint64(tbuf, uint64(c.Typ))
-	h.Write(tbuf)
-	h.Write(c.Val)
 }
 
 func (c Component) Equal(rhs ComponentPattern) bool {

--- a/std/encoding/name_bench_test.go
+++ b/std/encoding/name_bench_test.go
@@ -1,0 +1,97 @@
+package encoding_test
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"runtime"
+	"testing"
+
+	enc "github.com/named-data/ndnd/std/encoding"
+	tu "github.com/named-data/ndnd/std/utils/testutils"
+)
+
+func randomNames(count int, size int) []enc.Name {
+	names := make([]enc.Name, count)
+	for i := 0; i < count; i++ {
+		for j := 0; j < size; j++ {
+			bytes := make([]byte, 12+j)
+			rand.Read(bytes)
+			typ := max(enc.TLNum(uint16(binary.BigEndian.Uint16(bytes[:4])-1024)), 1024)
+			names[i] = append(names[i], enc.NewBytesComponent(typ, bytes[4:]))
+		}
+	}
+	return names
+}
+
+func benchmarkNameEncode(b *testing.B, size int, encode func(name enc.Name)) {
+	runtime.GC()
+	names := randomNames(b.N, size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encode(names[i])
+	}
+}
+
+func BenchmarkNameHash(b *testing.B) {
+	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.Hash() })
+}
+
+func BenchmarkNameStringEncode(b *testing.B) {
+	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.String() })
+}
+
+func BenchmarkNameTlvStrEncode(b *testing.B) {
+	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.TlvStr() })
+}
+
+func BenchmarkNameBytesEncode(b *testing.B) {
+	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.Bytes() })
+}
+
+func BenchmarkNameComponentStringEncode(b *testing.B) {
+	benchmarkNameEncode(b, 1, func(name enc.Name) { _ = name[0].String() })
+}
+
+func BenchmarkNameComponentTlvStrEncode(b *testing.B) {
+	benchmarkNameEncode(b, 1, func(name enc.Name) { _ = name[0].TlvStr() })
+}
+
+func BenchmarkNameClone(b *testing.B) {
+	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.Clone() })
+}
+
+func benchmarkNameDecode[T any](b *testing.B, size int, encode func(name enc.Name) T, decode func(e T)) {
+	names := randomNames(b.N, size)
+	nameEncs := make([]T, b.N)
+	for i := 0; i < b.N; i++ {
+		nameEncs[i] = encode(names[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decode(nameEncs[i])
+	}
+}
+
+func BenchmarkNameStringDecode(b *testing.B) {
+	benchmarkNameDecode(b, 20,
+		func(name enc.Name) string { return name.String() },
+		func(s string) { _ = tu.NoErrB(enc.NameFromStr(s)) })
+}
+
+func BenchmarkNameTlvStrDecode(b *testing.B) {
+	benchmarkNameDecode(b, 20,
+		func(name enc.Name) string { return name.TlvStr() },
+		func(s string) { _ = tu.NoErrB(enc.NameFromTlvStr(s)) })
+}
+
+func BenchmarkNameComponentStringDecode(b *testing.B) {
+	benchmarkNameDecode(b, 1,
+		func(name enc.Name) string { return name[0].String() },
+		func(s string) { _ = tu.NoErrB(enc.ComponentFromStr(s)) })
+}
+
+func BenchmarkNameComponentTlvStrDecode(b *testing.B) {
+	benchmarkNameDecode(b, 1,
+		func(name enc.Name) string { return name[0].TlvStr() },
+		func(s string) { _ = tu.NoErrB(enc.ComponentFromTlvStr(s)) })
+}

--- a/std/encoding/name_pattern.go
+++ b/std/encoding/name_pattern.go
@@ -68,8 +68,17 @@ func (n Name) EncodingLength() int {
 // Clone returns a deep copy of a Name
 func (n Name) Clone() Name {
 	ret := make(Name, len(n))
+	valLen := 0
+	for i := range n {
+		valLen += len(n[i].Val)
+	}
+	buf := make([]byte, valLen)
 	for i, c := range n {
-		ret[i] = c.Clone()
+		ret[i].Typ = c.Typ
+		vlen := len(c.Val)
+		copy(buf, c.Val)
+		ret[i].Val = buf[:vlen]
+		buf = buf[vlen:]
 	}
 	return ret
 }

--- a/std/encoding/name_test.go
+++ b/std/encoding/name_test.go
@@ -1,6 +1,8 @@
 package encoding_test
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"strings"
 	"testing"
@@ -436,4 +438,96 @@ func TestNamePrefix(t *testing.T) {
 	require.Equal(t, "/a", n.Prefix(-3).String())
 	require.Equal(t, "/", n.Prefix(-4).String())
 	require.Equal(t, "/", n.Prefix(-5).String())
+}
+
+func TestNameTlvStr(t *testing.T) {
+	tu.SetT(t)
+	for _, name := range randomNames(1000, 20) {
+		comp2 := tu.NoErr(enc.ComponentFromTlvStr(name[10].TlvStr()))
+		require.Equal(t, name[10], comp2)
+		name2 := tu.NoErr(enc.NameFromTlvStr(name.TlvStr()))
+		require.Equal(t, name, name2)
+	}
+}
+
+func benchmarkNameEncode(b *testing.B, size int, encode func(name enc.Name)) {
+	names := randomNames(b.N, size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encode(names[i])
+	}
+}
+
+func BenchmarkNameHash(b *testing.B) {
+	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.Hash() })
+}
+
+func BenchmarkNameStringEncode(b *testing.B) {
+	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.String() })
+}
+
+func BenchmarkNameTlvStrEncode(b *testing.B) {
+	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.TlvStr() })
+}
+
+func BenchmarkNameBytesEncode(b *testing.B) {
+	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.Bytes() })
+}
+
+func BenchmarkNameComponentStringEncode(b *testing.B) {
+	benchmarkNameEncode(b, 1, func(name enc.Name) { _ = name[0].String() })
+}
+
+func BenchmarkNameComponentTlvStrEncode(b *testing.B) {
+	benchmarkNameEncode(b, 1, func(name enc.Name) { _ = name[0].TlvStr() })
+}
+
+func benchmarkNameDecode[T any](b *testing.B, size int, encode func(name enc.Name) T, decode func(e T)) {
+	names := randomNames(b.N, size)
+	nameEncs := make([]T, b.N)
+	for i := 0; i < b.N; i++ {
+		nameEncs[i] = encode(names[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decode(nameEncs[i])
+	}
+}
+
+func BenchmarkNameStringDecode(b *testing.B) {
+	benchmarkNameDecode(b, 20,
+		func(name enc.Name) string { return name.String() },
+		func(s string) { _ = tu.NoErrB(enc.NameFromStr(s)) })
+}
+
+func BenchmarkNameTlvStrDecode(b *testing.B) {
+	benchmarkNameDecode(b, 20,
+		func(name enc.Name) string { return name.TlvStr() },
+		func(s string) { _ = tu.NoErrB(enc.NameFromTlvStr(s)) })
+}
+
+func BenchmarkNameComponentStringDecode(b *testing.B) {
+	benchmarkNameDecode(b, 1,
+		func(name enc.Name) string { return name[0].String() },
+		func(s string) { _ = tu.NoErrB(enc.ComponentFromStr(s)) })
+}
+
+func BenchmarkNameComponentTlvStrDecode(b *testing.B) {
+	benchmarkNameDecode(b, 1,
+		func(name enc.Name) string { return name[0].TlvStr() },
+		func(s string) { _ = tu.NoErrB(enc.ComponentFromTlvStr(s)) })
+}
+
+// randomNames generates random names for benchmarking.
+func randomNames(count int, size int) []enc.Name {
+	names := make([]enc.Name, count)
+	for i := 0; i < count; i++ {
+		for j := 0; j < size; j++ {
+			bytes := make([]byte, 12+j)
+			rand.Read(bytes)
+			typ := max(enc.TLNum(uint16(binary.BigEndian.Uint16(bytes[:4])-1024)), 1024)
+			names[i] = append(names[i], enc.NewBytesComponent(typ, bytes[4:]))
+		}
+	}
+	return names
 }

--- a/std/encoding/name_test.go
+++ b/std/encoding/name_test.go
@@ -1,10 +1,7 @@
 package encoding_test
 
 import (
-	"crypto/rand"
-	"encoding/binary"
 	"encoding/hex"
-	"runtime"
 	"strings"
 	"testing"
 	"unsafe"
@@ -458,91 +455,4 @@ func TestNameClone(t *testing.T) {
 	require.Equal(t, n, n2)
 	require.True(t, unsafe.SliceData(n) != unsafe.SliceData(n2))
 	require.True(t, unsafe.SliceData(n[0].Val) != unsafe.SliceData(n2[0].Val))
-}
-
-func benchmarkNameEncode(b *testing.B, size int, encode func(name enc.Name)) {
-	runtime.GC()
-	names := randomNames(b.N, size)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		encode(names[i])
-	}
-}
-
-func BenchmarkNameHash(b *testing.B) {
-	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.Hash() })
-}
-
-func BenchmarkNameStringEncode(b *testing.B) {
-	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.String() })
-}
-
-func BenchmarkNameTlvStrEncode(b *testing.B) {
-	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.TlvStr() })
-}
-
-func BenchmarkNameBytesEncode(b *testing.B) {
-	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.Bytes() })
-}
-
-func BenchmarkNameComponentStringEncode(b *testing.B) {
-	benchmarkNameEncode(b, 1, func(name enc.Name) { _ = name[0].String() })
-}
-
-func BenchmarkNameComponentTlvStrEncode(b *testing.B) {
-	benchmarkNameEncode(b, 1, func(name enc.Name) { _ = name[0].TlvStr() })
-}
-
-func BenchmarkNameClone(b *testing.B) {
-	benchmarkNameEncode(b, 20, func(name enc.Name) { _ = name.Clone() })
-}
-
-func benchmarkNameDecode[T any](b *testing.B, size int, encode func(name enc.Name) T, decode func(e T)) {
-	names := randomNames(b.N, size)
-	nameEncs := make([]T, b.N)
-	for i := 0; i < b.N; i++ {
-		nameEncs[i] = encode(names[i])
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		decode(nameEncs[i])
-	}
-}
-
-func BenchmarkNameStringDecode(b *testing.B) {
-	benchmarkNameDecode(b, 20,
-		func(name enc.Name) string { return name.String() },
-		func(s string) { _ = tu.NoErrB(enc.NameFromStr(s)) })
-}
-
-func BenchmarkNameTlvStrDecode(b *testing.B) {
-	benchmarkNameDecode(b, 20,
-		func(name enc.Name) string { return name.TlvStr() },
-		func(s string) { _ = tu.NoErrB(enc.NameFromTlvStr(s)) })
-}
-
-func BenchmarkNameComponentStringDecode(b *testing.B) {
-	benchmarkNameDecode(b, 1,
-		func(name enc.Name) string { return name[0].String() },
-		func(s string) { _ = tu.NoErrB(enc.ComponentFromStr(s)) })
-}
-
-func BenchmarkNameComponentTlvStrDecode(b *testing.B) {
-	benchmarkNameDecode(b, 1,
-		func(name enc.Name) string { return name[0].TlvStr() },
-		func(s string) { _ = tu.NoErrB(enc.ComponentFromTlvStr(s)) })
-}
-
-// randomNames generates random names for benchmarking.
-func randomNames(count int, size int) []enc.Name {
-	names := make([]enc.Name, count)
-	for i := 0; i < count; i++ {
-		for j := 0; j < size; j++ {
-			bytes := make([]byte, 12+j)
-			rand.Read(bytes)
-			typ := max(enc.TLNum(uint16(binary.BigEndian.Uint16(bytes[:4])-1024)), 1024)
-			names[i] = append(names[i], enc.NewBytesComponent(typ, bytes[4:]))
-		}
-	}
-	return names
 }

--- a/std/utils/testutils/error.go
+++ b/std/utils/testutils/error.go
@@ -21,3 +21,17 @@ func Err[T any](_ T, err error) error {
 	require.Error(testT, err)
 	return err
 }
+
+func NoErrB[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func ErrB[T any](_ T, err error) error {
+	if err == nil {
+		panic("expected error")
+	}
+	return err
+}


### PR DESCRIPTION
Better version of #121

> enc.Name.String() is too slow for usage in map[string]... (since go doesn't support custom keys). Using a cryptographic hash is too expensive and xxhash is not collision free.

`TlvStr()` returns a TLV encoded name string. I realised (bit late) that our encoding is very efficient. Decoding is slightly slower than the earlier version but that's fine since map reads need only encode.

Surprisingly the TLV encode is even faster than just copying the memory over (huh go?)

```
# /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkName github.com/named-data/ndnd/std/encoding
goos: linux
goarch: amd64
pkg: github.com/named-data/ndnd/std/encoding
cpu: AMD EPYC 7702P 64-Core Processor               
BenchmarkNameHash-128                            1000000              1028 ns/op             160 B/op         20 allocs/op
BenchmarkNameStringEncode-128                     112825             10550 ns/op            3467 B/op         30 allocs/op
BenchmarkNameTlvStrEncode-128                    2813996               415.0 ns/op           448 B/op          1 allocs/op
BenchmarkNameBytesEncode-128                     2309168               436.1 ns/op           448 B/op          1 allocs/op
BenchmarkNameComponentStringEncode-128           2747901               468.1 ns/op            95 B/op          4 allocs/op
BenchmarkNameComponentTlvStrEncode-128          24632506                46.90 ns/op           16 B/op          1 allocs/op
BenchmarkNameStringDecode-128                      94125             12469 ns/op            2059 B/op         22 allocs/op
BenchmarkNameTlvStrDecode-128                     575214              2039 ns/op            2400 B/op          5 allocs/op
BenchmarkNameComponentStringDecode-128           4044622               290.7 ns/op            23 B/op          1 allocs/op
BenchmarkNameComponentTlvStrDecode-128           8897691               131.1 ns/op            48 B/op          2 allocs/op
PASS
ok      github.com/named-data/ndnd/std/encoding 244.251s
```

After moving `Name.Hash()` to TLV (reduce alloc):
```
BenchmarkNameHash-128            2060044               528.0 ns/op           448 B/op          1 allocs/op
```

Same for `Name.Clone()`
```
Before -
BenchmarkNameClone-128            800976              1820 ns/op            1128 B/op         21 allocs/op
After -
BenchmarkNameClone-128           1503552               735.4 ns/op          1056 B/op          2 allocs/op
```