### PR TITLE
Switch default socket to /var/run/nfd/nfd.sock on Mac

### DIFF
--- a/fw/core/config.go
+++ b/fw/core/config.go
@@ -9,6 +9,7 @@ package core
 
 import (
 	"path/filepath"
+	"runtime"
 )
 
 // Global initial configuration of the forwarder.
@@ -194,6 +195,9 @@ func DefaultConfig() *Config {
 
 	c.Faces.Unix.Enabled = true
 	c.Faces.Unix.SocketPath = "/run/nfd/nfd.sock"
+	if runtime.GOOS == "darwin" {
+		c.Faces.Unix.SocketPath = "/var/run/nfd/nfd.sock"
+	}
 
 	c.Faces.WebSocket.Enabled = true
 	c.Faces.WebSocket.Bind = ""

--- a/fw/yanfd.sample.yml
+++ b/fw/yanfd.sample.yml
@@ -47,8 +47,10 @@ faces:
     # Whether to enable Unix stream transports
     enabled: true
     # Location of the socket file
-    ## If running on Mac, use /var/run/nfd/nfd.sock
-    socket_path: /run/nfd/nfd.sock
+    # On Windows, uses ${TEMP}\\nfd\\nfd.sock
+    # On Mac, uses /var/run/nfd/nfd.sock
+    # Uncomment the line below to manually set socket path
+    # socket_path: /run/nfd/nfd.sock
 
   websocket:
     # Whether to enable WebSocket listener

--- a/fw/yanfd.sample.yml
+++ b/fw/yanfd.sample.yml
@@ -47,6 +47,7 @@ faces:
     # Whether to enable Unix stream transports
     enabled: true
     # Location of the socket file
+    ## If running on Mac, use /var/run/nfd/nfd.sock
     socket_path: /run/nfd/nfd.sock
 
   websocket:

--- a/std/engine/client_conf.go
+++ b/std/engine/client_conf.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"strings"
+	"runtime"
 )
 
 type ClientConfig struct {
@@ -12,8 +13,12 @@ type ClientConfig struct {
 
 func GetClientConfig() ClientConfig {
 	// Default configuration
+	transportUri := "unix:///run/nfd/nfd.sock"
+	if runtime.GOOS == "darwin" {
+		transportUri = "unix:///var/run/nfd/nfd.sock"
+	}
 	config := ClientConfig{
-		TransportUri: "unix:///run/nfd/nfd.sock",
+		TransportUri: transportUri,
 	}
 
 	// Order of increasing priority

--- a/std/engine/client_conf.go
+++ b/std/engine/client_conf.go
@@ -3,8 +3,8 @@ package engine
 import (
 	"bufio"
 	"os"
-	"strings"
 	"runtime"
+	"strings"
 )
 
 type ClientConfig struct {


### PR DESCRIPTION
#144 

Checks operating system before choosing socket file.
If on Mac, use /var/run/nfd/nfd.sock
Otherwise, use /run/nfd/nfd.sock

Fixes an issue where Mac gives a permission denied error when trying to create a file in the /run folder.