### PR TITLE
trust_config: optionally ignore validity period

### DIFF
--- a/std/ndn/client.go
+++ b/std/ndn/client.go
@@ -161,6 +161,8 @@ type ValidateExtArgs struct {
 	CertNextHop optional.Optional[uint64]
 	// UseDataNameFwHint overrides trust config option.
 	UseDataNameFwHint optional.Optional[bool]
+	// IgnoreValidity ignores validity period in the validation chain.
+	IgnoreValidity optional.Optional[bool]
 }
 
 // Announcement are the arguments for the announce prefix API.

--- a/std/object/client_trust.go
+++ b/std/object/client_trust.go
@@ -46,6 +46,7 @@ func (c *Client) ValidateExt(args ndn.ValidateExtArgs) {
 		Callback:          args.Callback,
 		OverrideName:      overrideName,
 		UseDataNameFwHint: args.UseDataNameFwHint,
+		IgnoreValidity:    args.IgnoreValidity,
 		Fetch: func(name enc.Name, config *ndn.InterestConfig, callback ndn.ExpressCallbackFunc) {
 			config.NextHopId = args.CertNextHop
 			c.ExpressR(ndn.ExpressRArgs{


### PR DESCRIPTION
Override validation policies to ignore certificate expiration. This is quite dangerous option and should be available only in the advanced validation API `ValidateExt()`

I know it's probably a bit controversial, but it (has the potential to) buy us some time before "validating old data" is completely solved.