### PR TITLE
introduce ignoreValidity in SVS related logic

### DIFF
--- a/std/ndn/client.go
+++ b/std/ndn/client.go
@@ -125,6 +125,8 @@ type ConsumeExtArgs struct {
 	OnProgress func(status ConsumeState)
 	// NoMetadata disables fetching RDR metadata (advanced usage).
 	NoMetadata bool
+	// IgnoreValidity ignores validity period in the validation chain
+	IgnoreValidity optional.Optional[bool]
 }
 
 // ExpressRArgs are the arguments for the express retry API.

--- a/std/object/client_consume.go
+++ b/std/object/client_consume.go
@@ -63,29 +63,31 @@ func (c *Client) consumeObject(state *ConsumeState) {
 		// if metadata fetching is disabled, just attempt to fetch one segment
 		// with the prefix, then get the versioned name from the segment.
 		if state.args.NoMetadata {
-			c.fetchDataByPrefix(name, state.args.TryStore, func(data ndn.Data, err error) {
-				if err != nil {
-					state.finalizeError(err)
-					return
-				}
-				meta, err := extractSegMetadata(data)
+			c.fetchDataByPrefix(name, state.args.TryStore, state.args.IgnoreValidity.GetOr(false),
+				func(data ndn.Data, err error) {
+					if err != nil {
+						state.finalizeError(err)
+						return
+					}
+					meta, err := extractSegMetadata(data)
+					if err != nil {
+						state.finalizeError(err)
+						return
+					}
+					c.consumeObjectWithMeta(state, meta)
+				})
+			return
+		}
+
+		// fetch RDR metadata for this object
+		c.fetchMetadata(name, state.args.TryStore, state.args.IgnoreValidity.GetOr(false),
+			func(meta *rdr.MetaData, err error) {
 				if err != nil {
 					state.finalizeError(err)
 					return
 				}
 				c.consumeObjectWithMeta(state, meta)
 			})
-			return
-		}
-
-		// fetch RDR metadata for this object
-		c.fetchMetadata(name, state.args.TryStore, func(meta *rdr.MetaData, err error) {
-			if err != nil {
-				state.finalizeError(err)
-				return
-			}
-			c.consumeObjectWithMeta(state, meta)
-		})
 		return
 	}
 
@@ -104,6 +106,7 @@ func (c *Client) consumeObjectWithMeta(state *ConsumeState, meta *rdr.MetaData) 
 func (c *Client) fetchMetadata(
 	name enc.Name,
 	tryStore bool,
+	ignoreValidity bool,
 	callback func(meta *rdr.MetaData, err error),
 ) {
 	log.Debug(c, "Fetching object metadata", "name", name)
@@ -126,25 +129,29 @@ func (c *Client) fetchMetadata(
 				callback(nil, fmt.Errorf("%w: fetch metadata failed with result: %s", ndn.ErrNetwork, args.Result))
 				return
 			}
+			c.ValidateExt(ndn.ValidateExtArgs{
+				Data:           args.Data,
+				SigCovered:     args.SigCovered,
+				IgnoreValidity: optional.Some(ignoreValidity),
+				Callback: func(valid bool, err error) {
+					// validate with trust config
+					if !valid {
+						callback(nil, fmt.Errorf("%w: validate metadata failed: %w", ndn.ErrSecurity, err))
+						return
+					}
 
-			c.Validate(args.Data, args.SigCovered, func(valid bool, err error) {
-				// validate with trust config
-				if !valid {
-					callback(nil, fmt.Errorf("%w: validate metadata failed: %w", ndn.ErrSecurity, err))
-					return
-				}
+					// parse metadata
+					metadata, err := rdr.ParseMetaData(enc.NewWireView(args.Data.Content()), false)
+					if err != nil {
+						callback(nil, fmt.Errorf("%w: failed to parse object metadata: %w", ndn.ErrProtocol, err))
+						return
+					}
 
-				// parse metadata
-				metadata, err := rdr.ParseMetaData(enc.NewWireView(args.Data.Content()), false)
-				if err != nil {
-					callback(nil, fmt.Errorf("%w: failed to parse object metadata: %w", ndn.ErrProtocol, err))
-					return
-				}
-
-				// clone fields for lifetime
-				metadata.Name = metadata.Name.Clone()
-				metadata.FinalBlockID = slices.Clone(metadata.FinalBlockID)
-				callback(metadata, nil)
+					// clone fields for lifetime
+					metadata.Name = metadata.Name.Clone()
+					metadata.FinalBlockID = slices.Clone(metadata.FinalBlockID)
+					callback(metadata, nil)
+				},
 			})
 		},
 	})
@@ -154,6 +161,7 @@ func (c *Client) fetchMetadata(
 func (c *Client) fetchDataByPrefix(
 	name enc.Name,
 	tryStore bool,
+	ignoreValidity bool,
 	callback func(data ndn.Data, err error),
 ) {
 	log.Debug(c, "Fetching data with prefix", "name", name)
@@ -176,14 +184,18 @@ func (c *Client) fetchDataByPrefix(
 				callback(nil, fmt.Errorf("%w: fetch by prefix failed with result: %s", ndn.ErrNetwork, args.Result))
 				return
 			}
+			c.ValidateExt(ndn.ValidateExtArgs{
+				Data:           args.Data,
+				SigCovered:     args.SigCovered,
+				IgnoreValidity: optional.Some(ignoreValidity),
+				Callback: func(valid bool, err error) {
+					if !valid {
+						callback(nil, fmt.Errorf("%w: validate by prefix failed: %w", ndn.ErrSecurity, err))
+						return
+					}
 
-			c.Validate(args.Data, args.SigCovered, func(valid bool, err error) {
-				if !valid {
-					callback(nil, fmt.Errorf("%w: validate by prefix failed: %w", ndn.ErrSecurity, err))
-					return
-				}
-
-				callback(args.Data, nil)
+					callback(args.Data, nil)
+				},
 			})
 		},
 	})

--- a/std/object/client_consume_seg.go
+++ b/std/object/client_consume_seg.go
@@ -283,12 +283,17 @@ func (s *rrSegFetcher) handleResult(args ndn.ExpressCallbackArgs, state *Consume
 // It is necessary that this function be called only from one goroutine - the engine.
 // The notable exception here is when there is a timeout, which has a separate goroutine.
 func (s *rrSegFetcher) handleData(args ndn.ExpressCallbackArgs, state *ConsumeState) {
-	s.client.Validate(args.Data, args.SigCovered, func(valid bool, err error) {
-		if !valid {
-			state.finalizeError(fmt.Errorf("%w: validate seg failed: %w", ndn.ErrSecurity, err))
-		} else {
-			s.handleValidatedData(args, state)
-		}
+	s.client.ValidateExt(ndn.ValidateExtArgs{
+		Data:           args.Data,
+		SigCovered:     args.SigCovered,
+		IgnoreValidity: state.args.IgnoreValidity,
+		Callback: func(valid bool, err error) {
+			if !valid {
+				state.finalizeError(fmt.Errorf("%w: validate seg failed: %w", ndn.ErrSecurity, err))
+			} else {
+				s.handleValidatedData(args, state)
+			}
+		},
 	})
 }
 

--- a/std/sync/svs_alo.go
+++ b/std/sync/svs_alo.go
@@ -140,6 +140,14 @@ func NewSvsALO(opts SvsAloOpts) (*SvsALO, error) {
 		}, s.state)
 	}
 
+	// Overeide IgnoreValidity from SVS (incorect but practical)
+	if latest, ok := s.opts.Snapshot.(*SnapshotNodeLatest); ok {
+		latest.IgnoreValidity = s.opts.Svs.IgnoreValidity
+	}
+	if history, ok := s.opts.Snapshot.(*SnapshotNodeHistory); ok {
+		history.IgnoreValidity = s.opts.Svs.IgnoreValidity
+	}
+
 	return s, nil
 }
 

--- a/std/sync/svs_alo_data.go
+++ b/std/sync/svs_alo_data.go
@@ -114,81 +114,86 @@ func (s *SvsALO) consumeCheck(node enc.Name) {
 // check to fetch more objects if necessary.
 func (s *SvsALO) consumeObject(node enc.Name, boot uint64, seq uint64) {
 	fetchName := s.objectName(node, boot, seq)
-	s.client.Consume(fetchName, func(status ndn.ConsumeState) {
-		s.mutex.Lock()
-		defer s.mutex.Unlock()
+	s.client.ConsumeExt(ndn.ConsumeExtArgs{
+		Name: fetchName,
+		// inherit ignoreValidity from SVS, not correct but practical
+		IgnoreValidity: s.opts.Svs.IgnoreValidity,
+		Callback: func(status ndn.ConsumeState) {
+			s.mutex.Lock()
+			defer s.mutex.Unlock()
 
-		// Always check if we can fetch more
-		defer s.consumeCheck(node)
+			// Always check if we can fetch more
+			defer s.consumeCheck(node)
 
-		// Get the state vector entry
-		hash := node.TlvStr()
-		entry := s.state.Get(hash, boot)
+			// Get the state vector entry
+			hash := node.TlvStr()
+			entry := s.state.Get(hash, boot)
 
-		// Check if this is already delivered
-		if seq <= entry.Known {
-			return
-		}
-
-		// Get the list of subscribers
-		subscribers := slices.Collect(s.nodePs.Subs(node))
-
-		// Check if we have to deliver this data
-		if entry.SnapBlock != 0 || len(subscribers) == 0 {
-			entry.Pending = min(entry.Pending, seq-1)
-			s.state.Set(hash, boot, entry)
-			return
-		}
-
-		// Check for errors
-		if err := status.Error(); err != nil {
-			// Propagate the error to application
-			s.queueError(&ErrSync{
-				Publisher: node,
-				BootTime:  boot,
-				Err:       err,
-			})
-
-			// TODO: exponential backoff
-			time.AfterFunc(2*time.Second, func() {
-				s.consumeObject(node, boot, seq)
-			})
-			return
-		}
-
-		// Initialize the pending map
-		if entry.PendingPubs == nil {
-			entry.PendingPubs = make(map[uint64]SvsPub)
-			s.state.Set(hash, boot, entry)
-		}
-
-		// Store the content for in-order delivery
-		// The size of this map is upper bounded
-		entry.PendingPubs[seq] = SvsPub{
-			Publisher: node,
-			Content:   status.Content(),
-			DataName:  status.Name(),
-			BootTime:  boot,
-			SeqNum:    seq,
-		}
-
-		for {
-			// Check if the next seq is available
-			nextSeq := entry.Known + 1
-			pub, ok := entry.PendingPubs[nextSeq]
-			if !ok {
-				break
+			// Check if this is already delivered
+			if seq <= entry.Known {
+				return
 			}
 
-			// Update known state
-			entry.Known = nextSeq
-			delete(entry.PendingPubs, nextSeq)
-			s.state.Set(hash, boot, entry)
+			// Get the list of subscribers
+			subscribers := slices.Collect(s.nodePs.Subs(node))
 
-			// Deliver the data to application
-			pub.subcribers = subscribers // use most current list
-			s.queuePub(pub)
-		}
+			// Check if we have to deliver this data
+			if entry.SnapBlock != 0 || len(subscribers) == 0 {
+				entry.Pending = min(entry.Pending, seq-1)
+				s.state.Set(hash, boot, entry)
+				return
+			}
+
+			// Check for errors
+			if err := status.Error(); err != nil {
+				// Propagate the error to application
+				s.queueError(&ErrSync{
+					Publisher: node,
+					BootTime:  boot,
+					Err:       err,
+				})
+
+				// TODO: exponential backoff
+				time.AfterFunc(2*time.Second, func() {
+					s.consumeObject(node, boot, seq)
+				})
+				return
+			}
+
+			// Initialize the pending map
+			if entry.PendingPubs == nil {
+				entry.PendingPubs = make(map[uint64]SvsPub)
+				s.state.Set(hash, boot, entry)
+			}
+
+			// Store the content for in-order delivery
+			// The size of this map is upper bounded
+			entry.PendingPubs[seq] = SvsPub{
+				Publisher: node,
+				Content:   status.Content(),
+				DataName:  status.Name(),
+				BootTime:  boot,
+				SeqNum:    seq,
+			}
+
+			for {
+				// Check if the next seq is available
+				nextSeq := entry.Known + 1
+				pub, ok := entry.PendingPubs[nextSeq]
+				if !ok {
+					break
+				}
+
+				// Update known state
+				entry.Known = nextSeq
+				delete(entry.PendingPubs, nextSeq)
+				s.state.Set(hash, boot, entry)
+
+				// Deliver the data to application
+				pub.subcribers = subscribers // use most current list
+				s.queuePub(pub)
+			}
+		},
 	})
 }
 


### PR DESCRIPTION
A subsequent patch to #157. Adding this flag to all SVS related logic: SVSData, Snapshot, Data consumed by SVS-ALO. Verified in Ownly. The flag is optional so other SVS apps (say dv) won't be affected.