### PR TITLE
Introduce DNS Challenge

### DIFF
--- a/std/security/ndncert/challenge_dns.go
+++ b/std/security/ndncert/challenge_dns.go
@@ -1,0 +1,123 @@
+package ndncert
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/named-data/ndnd/std/types/optional"
+)
+
+const (
+	KwRecordName    = "record-name"
+	KwExpectedValue = "expected-value"
+
+	DNSPrefix = "_ndncert-challenge"
+)
+
+// ChallengeDns implements the DNS-01 challenge following Let's Encrypt practices.
+// The challenge allows certificate requesters to prove domain ownership by creating
+// a DNS TXT record containing a challenge token.
+//
+// Challenge Flow:
+// 1. Requester provides domain name they want to validate
+// 2. CA generates challenge token and responds with DNS record details
+// 3. Requester creates TXT record at _ndncert-challenge.<domain> with challenge response
+// 4. Requester confirms record is in place
+// 5. CA performs DNS lookup to verify the TXT record exists
+type ChallengeDns struct {
+	// DomainCallback is called to get the domain name from the user.
+	// It receives the challenge status for user prompting.
+	DomainCallback func(status string) string
+
+	// ConfirmationCallback is called to get confirmation from user that
+	// they have created the required DNS record.
+	// It receives the record details and status for user prompting.
+	ConfirmationCallback func(recordName, expectedValue, status string) string
+
+	// internal state for multi-step challenge
+	domain        string
+	recordName    string
+	expectedValue string
+}
+
+func (*ChallengeDns) Name() string {
+	return KwDns
+}
+
+func (c *ChallengeDns) Request(input ParamMap, status optional.Optional[string]) (ParamMap, error) {
+	// Validate challenge configuration
+	if c.DomainCallback == nil || c.ConfirmationCallback == nil {
+		return nil, fmt.Errorf("dns challenge not configured")
+	}
+
+	statusStr := status.GetOr("")
+
+	// Initial request: get domain from user
+	if input == nil {
+		c.domain = c.DomainCallback(statusStr)
+		if c.domain == "" {
+			return nil, fmt.Errorf("no domain provided")
+		}
+
+		if !isValidDomainName(c.domain) {
+			return nil, fmt.Errorf("invalid domain name: %s", c.domain)
+		}
+
+		return ParamMap{
+			KwDomain: []byte(c.domain),
+		}, nil
+	}
+
+	// Handle different challenge statuses
+	switch statusStr {
+	case "need-record":
+		// Extract DNS record information from input parameters
+		if recordNameBytes, ok := input[KwRecordName]; ok {
+			c.recordName = string(recordNameBytes)
+		}
+		if expectedValueBytes, ok := input[KwExpectedValue]; ok {
+			c.expectedValue = string(expectedValueBytes)
+		}
+
+		// Get confirmation from user that they've created the DNS record
+		confirmation := c.ConfirmationCallback(c.recordName, c.expectedValue, statusStr)
+		if confirmation != "ready" {
+			return nil, fmt.Errorf("expected 'ready' confirmation, got: %s", confirmation)
+		}
+
+		return ParamMap{
+			KwConfirmation: []byte("ready"),
+		}, nil
+
+	case "wrong-record":
+		// DNS verification failed, ask user to retry
+		confirmation := c.ConfirmationCallback(c.recordName, c.expectedValue, statusStr)
+		if confirmation != "ready" {
+			return nil, fmt.Errorf("expected 'ready' confirmation, got: %s", confirmation)
+		}
+
+		return ParamMap{
+			KwConfirmation: []byte("ready"),
+		}, nil
+
+	case "ready-for-validation":
+		// Automatic validation phase - no user input needed
+		return ParamMap{
+			"verify": []byte("now"),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown DNS challenge status: %s", statusStr)
+	}
+}
+
+// isValidDomainName validates domain name format according to RFC 1123
+func isValidDomainName(domain string) bool {
+	if len(domain) == 0 || len(domain) > 253 {
+		return false
+	}
+
+	// RFC 1123 compliant hostname pattern
+	domainPattern := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
+	return domainPattern.MatchString(domain)
+}

--- a/std/security/ndncert/challenge_dns_test.go
+++ b/std/security/ndncert/challenge_dns_test.go
@@ -1,0 +1,240 @@
+package ndncert_test
+
+import (
+	"testing"
+
+	"github.com/named-data/ndnd/std/security/ndncert"
+	"github.com/named-data/ndnd/std/types/optional"
+)
+
+func TestChallengeDns_Name(t *testing.T) {
+	challenge := &ndncert.ChallengeDns{}
+	if challenge.Name() != "dns" {
+		t.Errorf("Expected challenge name 'dns', got '%s'", challenge.Name())
+	}
+}
+
+func TestChallengeDns_InitialRequest(t *testing.T) {
+	domainCalled := false
+	expectedDomain := "example.com"
+
+	challenge := &ndncert.ChallengeDns{
+		DomainCallback: func(status string) string {
+			domainCalled = true
+			return expectedDomain
+		},
+		ConfirmationCallback: func(recordName, expectedValue, status string) string {
+			return "ready"
+		},
+	}
+
+	params, err := challenge.Request(nil, optional.Optional[string]{})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if !domainCalled {
+		t.Error("Expected domain callback to be called")
+	}
+
+	if string(params["domain"]) != expectedDomain {
+		t.Errorf("Expected domain parameter '%s', got '%s'", expectedDomain, string(params["domain"]))
+	}
+}
+
+func TestChallengeDns_InvalidDomain(t *testing.T) {
+	challenge := &ndncert.ChallengeDns{
+		DomainCallback: func(status string) string {
+			return "invalid..domain" // Invalid domain format
+		},
+		ConfirmationCallback: func(recordName, expectedValue, status string) string {
+			return "ready"
+		},
+	}
+
+	_, err := challenge.Request(nil, optional.Optional[string]{})
+	if err == nil {
+		t.Error("Expected error for invalid domain, got none")
+	}
+}
+
+func TestChallengeDns_NeedRecordStatus(t *testing.T) {
+	confirmationCalled := false
+	expectedRecordName := "_ndncert-challenge.example.com"
+	expectedValue := "test-token-hash"
+
+	challenge := &ndncert.ChallengeDns{
+		DomainCallback: func(status string) string {
+			return "example.com"
+		},
+		ConfirmationCallback: func(recordName, expValue, status string) string {
+			confirmationCalled = true
+			if recordName != expectedRecordName {
+				t.Errorf("Expected record name '%s', got '%s'", expectedRecordName, recordName)
+			}
+			if expValue != expectedValue {
+				t.Errorf("Expected value '%s', got '%s'", expectedValue, expValue)
+			}
+			if status != "need-record" {
+				t.Errorf("Expected status 'need-record', got '%s'", status)
+			}
+			return "ready"
+		},
+	}
+
+	// Simulate input parameters from CA response
+	input := ndncert.ParamMap{
+		"record-name":    []byte(expectedRecordName),
+		"expected-value": []byte(expectedValue),
+	}
+
+	status := optional.Some("need-record")
+	params, err := challenge.Request(input, status)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if !confirmationCalled {
+		t.Error("Expected confirmation callback to be called")
+	}
+
+	if string(params["confirmation"]) != "ready" {
+		t.Errorf("Expected confirmation parameter 'ready', got '%s'", string(params["confirmation"]))
+	}
+}
+
+func TestChallengeDns_WrongRecordStatus(t *testing.T) {
+	challenge := &ndncert.ChallengeDns{
+		DomainCallback: func(status string) string {
+			return "example.com"
+		},
+		ConfirmationCallback: func(recordName, expectedValue, status string) string {
+			if status != "wrong-record" {
+				t.Errorf("Expected status 'wrong-record', got '%s'", status)
+			}
+			return "ready"
+		},
+	}
+
+	input := ndncert.ParamMap{
+		"record-name":    []byte("_ndncert-challenge.example.com"),
+		"expected-value": []byte("test-token-hash"),
+	}
+
+	status := optional.Some("wrong-record")
+	params, err := challenge.Request(input, status)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if string(params["confirmation"]) != "ready" {
+		t.Errorf("Expected confirmation parameter 'ready', got '%s'", string(params["confirmation"]))
+	}
+}
+
+func TestChallengeDns_ReadyForValidationStatus(t *testing.T) {
+	challenge := &ndncert.ChallengeDns{
+		DomainCallback: func(status string) string {
+			return "example.com"
+		},
+		ConfirmationCallback: func(recordName, expectedValue, status string) string {
+			return "ready"
+		},
+	}
+
+	input := ndncert.ParamMap{}
+	status := optional.Some("ready-for-validation")
+	params, err := challenge.Request(input, status)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if string(params["verify"]) != "now" {
+		t.Errorf("Expected verify parameter 'now', got '%s'", string(params["verify"]))
+	}
+}
+
+func TestChallengeDns_UnknownStatus(t *testing.T) {
+	challenge := &ndncert.ChallengeDns{
+		DomainCallback: func(status string) string {
+			return "example.com"
+		},
+		ConfirmationCallback: func(recordName, expectedValue, status string) string {
+			return "ready"
+		},
+	}
+
+	input := ndncert.ParamMap{}
+	status := optional.Some("unknown-status")
+	_, err := challenge.Request(input, status)
+	if err == nil {
+		t.Error("Expected error for unknown status, got none")
+	}
+}
+
+func TestChallengeDns_NotConfigured(t *testing.T) {
+	// Test with missing domain callback
+	challenge := &ndncert.ChallengeDns{
+		ConfirmationCallback: func(recordName, expectedValue, status string) string {
+			return "ready"
+		},
+	}
+
+	_, err := challenge.Request(nil, optional.Optional[string]{})
+	if err == nil {
+		t.Error("Expected error for missing domain callback, got none")
+	}
+
+	// Test with missing confirmation callback
+	challenge2 := &ndncert.ChallengeDns{
+		DomainCallback: func(status string) string {
+			return "example.com"
+		},
+	}
+
+	_, err = challenge2.Request(nil, optional.Optional[string]{})
+	if err == nil {
+		t.Error("Expected error for missing confirmation callback, got none")
+	}
+}
+
+// Test domain validation helper functions (if we need to expose them for testing)
+func TestIsValidDomainName(t *testing.T) {
+	// Note: This test assumes isValidDomainName is exported
+	// If not exported, we can test through the challenge Request method
+	testCases := []struct {
+		domain string
+		valid  bool
+	}{
+		{"example.com", true},
+		{"sub.example.com", true},
+		{"test-domain.example.org", true},
+		{"a.b", true},
+		{"", false},
+		{"-example.com", false},
+		{"example-.com", false},
+		{"example..com", false},
+		{".example.com", false},
+		{"example.com.", false},
+	}
+
+	for _, tc := range testCases {
+		challenge := &ndncert.ChallengeDns{
+			DomainCallback: func(status string) string {
+				return tc.domain
+			},
+			ConfirmationCallback: func(recordName, expectedValue, status string) string {
+				return "ready"
+			},
+		}
+
+		_, err := challenge.Request(nil, optional.Optional[string]{})
+
+		if tc.valid && err != nil {
+			t.Errorf("Expected domain '%s' to be valid, got error: %v", tc.domain, err)
+		}
+		if !tc.valid && err == nil {
+			t.Errorf("Expected domain '%s' to be invalid, got no error", tc.domain)
+		}
+	}
+}

--- a/std/security/ndncert/constants.go
+++ b/std/security/ndncert/constants.go
@@ -10,6 +10,9 @@ import (
 const KwEmail = "email"
 const KwPin = "pin"
 const KwCode = "code"
+const KwDns = "dns"
+const KwDomain = "domain"
+const KwConfirmation = "confirmation"
 
 // Challenge Errors
 var ErrChallengeBefore = errors.New("challenge before request")


### PR DESCRIPTION
## Overview 
PR to add the DNS challenge support. It contains two parts: the client implementation and `certcli` support.

## Background
The DNS challenge [spec](https://github.com/UCLA-IRL/ndncert/blob/master/DNS-Challenge-Spec.md) tries to do things very similar to Let's Encrypt [dns-01](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge). Currently the testbed root CA already supports this challenge, feel free to test this code against it.

## Comments
Semi-related implementation decisions I deliberately made:
* No corresponding PROBE: I believe the NDN names derived from DNS names should follow a uniform name convention
* When DNS challenge is chosen, `certcli` skips the PROBE and forces to append the domain name under the CA name (e.g., /ndn/example.org)
* Spec does not define the record TTL, so does implementation. Up to users, but be careful.

## `certcli` Support
`certcli` usage to test the DNS challenge. It requires you to get the ndnd cert PEM for testbed root.

Hope the below can help you (assume you have `curl` and `base64`)
```bash
curl -s https://raw.githubusercontent.com/named-data/testbed/main/anchors/ndn-testbed-root.ndncert.2204.base64 | base64 -d | ./ndnd sec pem-encode > ca-cert.pem
```

Run the certificate client without specifying a challenge type to be prompted to choose:

```bash
./ndnd certcli ca-cert.pem
```

When prompted, select "3. dns" for DNS challenge.

### Direct DNS Challenge

Specify the DNS challenge directly:

```bash
./ndnd certcli --challenge=dns ca-cert.pem
```

### Pre-specify Domain

You can provide the domain name upfront to reduce prompts:

```bash
./ndnd certcli --challenge=dns --domain=example.org ca-cert.pem
```

## Challenge Flow

### Step 1: Domain Specification
- If `--domain` flag is not provided, you'll be prompted to enter the domain name
- The domain name must be valid according to RFC 1123 hostname format

### Step 2: DNS Record Creation
The client will display instructions like:
```
=== DNS CHALLENGE SETUP ===
Please create the following DNS TXT record:

Record Name: _ndncert-challenge.example.org
Record Type: TXT  
Record Value: a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456

Example DNS configuration:
_ndncert-challenge.example.org IN TXT "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"

After creating the DNS TXT record, press ENTER to continue verification...
```

### Step 3: DNS Record Creation (User Action)
Create the DNS TXT record using your DNS provider's interface

### Step 4: Verification
- Press ENTER to proceed with verification
- The CA will perform DNS lookup to verify the TXT record
- If verification fails, you'll be prompted to check the record and retry

### Step 5: Certificate Issuance
Same with the existing ndncert implementation
