### PR TITLE
e2e: test cat/put with routing convergence on new node joining

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,5 +66,8 @@ jobs:
       - name: Mark ndnd as executable
         run: chmod +x /usr/bin/ndnd
 
+      - name: Copy ndnd to e2e's bin folder
+        run: cp /usr/bin/ndnd .bin/
+
       - name: Run e2e tests
         run: make e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,9 @@ jobs:
         run: chmod +x /usr/bin/ndnd
 
       - name: Copy ndnd to e2e's bin folder
-        run: cp /usr/bin/ndnd .bin/
+        run: |
+          mkdir .bin/
+          cp /usr/bin/ndnd .bin/
 
       - name: Run e2e tests
         run: make e2e

--- a/e2e/test_002.py
+++ b/e2e/test_002.py
@@ -9,10 +9,11 @@ from minindn.apps.app_manager import AppManager
 from fw import NDNd_FW
 import dv_util
 
-def scenario(ndn: Minindn):
+def scenario(ndn: Minindn, network='/minindn'):
     """
-    This scenario tests routing convergence when a router joins
-    the network after the network has already converged.
+    This scenario tests routing convergence and cat/put operations
+    when a router joins the network
+    after the network has already converged.
     """
 
     # Choose a node with a single link to the network
@@ -27,13 +28,13 @@ def scenario(ndn: Minindn):
     downIntf.config(loss=99.99)
 
     info('Starting forwarder on nodes\n')
-    AppManager(ndn, ndn.net.hosts, NDNd_FW)
+    AppManager(ndn, ndn.net.hosts, NDNd_FW, network=network)
 
-    dv_util.setup(ndn)
+    dv_util.setup(ndn, network=network)
     dv_util.converge(others)
 
     # Make sure the node is really disconnected
-    if not dv_util.is_converged(others):
+    if not dv_util.is_converged(others, network=network):
         raise Exception('Routing did not converge on other nodes (?!)')
     if dv_util.is_converged(ndn.net.hosts):
         raise Exception('Routing converged on lazy node (?!)')
@@ -44,3 +45,23 @@ def scenario(ndn: Minindn):
 
     # Wait for convergence
     dv_util.converge(ndn.net.hosts)
+
+    # Ensure that cat/put works with the newly joined node
+    data = os.urandom(16).hex()
+    put_prefix = f'{network}/{lazy_node.name}/test'
+    cmd = f'ndnd put --expose "{put_prefix}" < <(echo {data}) &> put_log.txt &'
+    info(f'{lazy_node.name} {cmd}\n')
+    lazy_node.cmd(cmd)
+    dv_util.wait_prefix_pet_ready(
+        {node: {put_prefix} for node in ndn.net.hosts},
+        deadline=180
+    )
+
+    for node in random.sample(ndn.net.hosts, 8):
+        cmd = f'ndnd cat "{put_prefix}" > recv.bin 2> cat.log'
+        info(f'{node.name} {cmd}\n')
+        node.cmd(cmd)
+        cat_output = node.cmd(f'cat recv.bin').strip()
+        if cat_output != data:
+            info(node.cmd(f'cat cat.log'))
+            raise Exception(f'Test file contents ({cat_output=} != {data=}) do not match on {node.name}')

--- a/fw/fw/bestroute.go
+++ b/fw/fw/bestroute.go
@@ -107,7 +107,7 @@ func (s *BestRoute) AfterReceiveInterest(
 					return
 				}
 				packet.EgressRouter = oldEgress
-			// otherwise, normal forwarding
+				// otherwise, normal forwarding
 			} else {
 				if sent := s.SendInterest(packet, pitEntry, nh.Nexthop, inFace); sent {
 					return


### PR DESCRIPTION
Run with `python3 e2e/run_scenario.py --scenario test_002 --topo e2e/topo.sprint.conf` in minindn container

PR also fixes ci for e2e tests

Requesting @tianyuan129 review