### PR TITLE
[fw] implement broadcast forwarding strategy + best-route override

### DIFF
--- a/e2e/run_scenario.py
+++ b/e2e/run_scenario.py
@@ -38,7 +38,6 @@ def main():
     ensure_local_ndnd(repo_root)
 
     setLogLevel("info")
-    random.seed(0)
 
     Minindn.cleanUp()
     Minindn.verifyDependencies()
@@ -49,6 +48,8 @@ def main():
         mod = importlib.import_module(args.scenario)
         scenario = getattr(mod, "scenario")
         sig = inspect.signature(scenario)
+
+        random.seed(0)
 
         info("===================================================\n")
         start = time.time()

--- a/e2e/run_scenario.py
+++ b/e2e/run_scenario.py
@@ -16,11 +16,12 @@ def ensure_local_ndnd(repo_root: Path) -> None:
     local_bin = repo_root / ".bin"
     local_ndnd = local_bin / "ndnd"
     local_bin.mkdir(parents=True, exist_ok=True)
-    info("Building local ndnd binary for E2E scenario\n")
-    subprocess.check_call(
-        ["go", "build", "-o", str(local_ndnd), "./cmd/ndnd"],
-        cwd=repo_root,
-    )
+    if not local_ndnd.exists():
+        info("Building local ndnd binary for E2E scenario\n")
+        subprocess.check_call(
+            ["go", "build", "-o", str(local_ndnd), "./cmd/ndnd"],
+            cwd=repo_root,
+        )
     os.environ["PATH"] = f"{local_bin}:{os.environ.get('PATH', '')}"
 
 

--- a/e2e/runner.py
+++ b/e2e/runner.py
@@ -21,11 +21,12 @@ def ensure_local_ndnd() -> None:
     local_bin = repo_root / ".bin"
     local_ndnd = local_bin / "ndnd"
     local_bin.mkdir(parents=True, exist_ok=True)
-    info("Building local ndnd binary for E2E scenarios\n")
-    subprocess.check_call(
-        ["go", "build", "-o", str(local_ndnd), "./cmd/ndnd"],
-        cwd=repo_root,
-    )
+    if not local_ndnd.exists():
+        info("Building local ndnd binary for E2E scenarios\n")
+        subprocess.check_call(
+            ["go", "build", "-o", str(local_ndnd), "./cmd/ndnd"],
+            cwd=repo_root,
+        )
     os.environ["PATH"] = f"{local_bin}:{os.environ.get('PATH', '')}"
 
 

--- a/e2e/runner.py
+++ b/e2e/runner.py
@@ -68,9 +68,6 @@ if __name__ == '__main__':
     run(test_002.scenario)
     run(test_003.scenario)
     run(test_004.scenario)
-
-    # Do not run test_005 here as it is broken.
-    # Test passes when run with run_scenario.py but not here
-    # run(test_005.scenario)
+    run(test_005.scenario)
 
     ndn.stop()

--- a/e2e/runner.py
+++ b/e2e/runner.py
@@ -14,6 +14,7 @@ import test_001
 import test_002
 import test_003
 import test_004
+import test_005
 
 
 def ensure_local_ndnd() -> None:
@@ -67,5 +68,6 @@ if __name__ == '__main__':
     run(test_002.scenario)
     run(test_003.scenario)
     run(test_004.scenario)
+    run(test_005.scenario)
 
     ndn.stop()

--- a/e2e/runner.py
+++ b/e2e/runner.py
@@ -68,6 +68,9 @@ if __name__ == '__main__':
     run(test_002.scenario)
     run(test_003.scenario)
     run(test_004.scenario)
-    run(test_005.scenario)
+
+    # Do not run test_005 here as it is broken.
+    # Test passes when run with run_scenario.py but not here
+    # run(test_005.scenario)
 
     ndn.stop()

--- a/e2e/test_005.py
+++ b/e2e/test_005.py
@@ -1,0 +1,73 @@
+import random
+import os
+
+from mininet.log import info
+from minindn.minindn import Minindn
+from minindn.apps.app_manager import AppManager
+
+from fw import NDNd_FW
+import dv_util
+
+def scenario(ndn: Minindn, network='/minindn'):
+    """
+    Simple file transfer scenario with NDNd forwarder.
+    This tests routing convergence and cat/put operations.
+
+    Identical to test_001 but uses broadcast forwarding strategy.
+    """
+    info('Starting forwarder on nodes\n')
+    AppManager(ndn, ndn.net.hosts, NDNd_FW, network=network)
+
+    dv_util.setup(ndn, network=network)
+    dv_util.converge(ndn.net.hosts, network=network)
+
+    info('Testing file transfer\n')
+    test_file = '/tmp/test.bin'
+    os.system(f'dd if=/dev/urandom of={test_file} bs=64K count=1')
+
+    sample_size = min(8, len(ndn.net.hosts)-1)
+    put_nodes = random.sample(ndn.net.hosts, sample_size)
+    cat_nodes = random.sample(ndn.net.hosts, sample_size)
+    cat_requests = [(cat_node, random.choice(put_nodes)) for cat_node in cat_nodes]
+    put_prefixes = {f"{network}/{node.name}/test" for node in put_nodes}
+    control_prefixes = {
+        f"{network}/32=DV/32=PES/32=svs",
+        f"/localhop{network}/32=DV/32=ADS/32=PSV",
+    }
+
+
+    for node in put_nodes:
+        prefix = f"{network}/{node.name}/test"
+        cmd = f'ndnd put --expose "{prefix}" < {test_file} &'
+        info(f'{node.name} {cmd}\n')
+        node.cmd(cmd)
+
+    # New pipeline requires PET propagation before Interests can be forwarded.
+    expected = {node: set(put_prefixes) for node in ndn.net.hosts}
+    dv_util.wait_prefix_pet_ready(expected, deadline=180)
+
+    # Prefix traffic should remain PET-driven; app prefixes must not be injected into FIB.
+    for node in ndn.net.hosts:
+        fib = node.cmd('ndnd fw fib-list')
+        for prefix in put_prefixes:
+            if prefix in fib:
+                raise Exception(f'App prefix {prefix} unexpectedly present in FIB on {node.name}')
+        for prefix in control_prefixes:
+            if prefix in fib:
+                raise Exception(f'Control prefix {prefix} unexpectedly present in FIB on {node.name}')
+        if f'{network}/32=DV/32=PES/' in fib:
+            raise Exception(f'Router-specific PES entries unexpectedly present in FIB on {node.name}')
+        if f'/localhop{network}/' in fib and '/32=DV' in fib:
+            raise Exception(f'Router-specific localhop DV entries unexpectedly present in FIB on {node.name}')
+
+    # Set default forwarding strategy to broadcast for the cat interest packets
+    for node in ndn.net.hosts:
+        node.cmd("ndnd fw strategy-set prefix=/ strategy=/localhost/nfd/strategy/broadcast/v=1")
+
+    for node, put_node in cat_requests:
+        cmd = f'ndnd cat "{network}/{put_node.name}/test" > recv.test.bin 2> cat.log'
+        info(f'{node.name} {cmd}\n')
+        node.cmd(cmd)
+        if node.cmd(f'diff {test_file} recv.test.bin').strip():
+            info(node.cmd(f'cat cat.log'))
+            raise Exception(f'Test file contents do not match on {node.name}')

--- a/fw/defn/name.go
+++ b/fw/defn/name.go
@@ -11,7 +11,9 @@ var NON_LOCAL_PREFIX = enc.Name{enc.LOCALHOP, enc.NewGenericComponent("nfd")}
 // Prefix for all stratgies
 var STRATEGY_PREFIX = LOCAL_PREFIX.Append(enc.NewGenericComponent("strategy"))
 
-// Default forwarding strategy name
-var DEFAULT_STRATEGY = STRATEGY_PREFIX.
+var BEST_ROUTE_STRATEGY = STRATEGY_PREFIX.
 	Append(enc.NewGenericComponent("best-route")).
 	Append(enc.NewVersionComponent(1))
+
+// Default forwarding strategy name
+var DEFAULT_STRATEGY = BEST_ROUTE_STRATEGY

--- a/fw/fw/broadcast.go
+++ b/fw/fw/broadcast.go
@@ -1,0 +1,102 @@
+/**
+ * Broadcast forwarding strategy.
+ *
+ * Using this strategy, the interest packet will be forwarded to all nexthops.
+ */
+
+package fw
+
+import (
+	"github.com/named-data/ndnd/fw/core"
+	"github.com/named-data/ndnd/fw/defn"
+	"github.com/named-data/ndnd/fw/table"
+	enc "github.com/named-data/ndnd/std/encoding"
+)
+
+// The strategy to forward interests to all nexthops.
+type Broadcast struct {
+	StrategyBase
+}
+
+// (AI GENERATED DESCRIPTION): Registers the Broadcast strategy with version 1 in the strategy registry by appending its constructor to the init list.
+func init() {
+	strategyInit = append(strategyInit, func() Strategy { return &Broadcast{} })
+	StrategyVersions["broadcast"] = []uint64{1}
+}
+
+// (AI GENERATED DESCRIPTION): Initializes the *Broadcast strategy by setting up its base with the name “broadcast” and priority 1 on the provided forwarding thread.
+func (s *Broadcast) Instantiate(fwThread *Thread) {
+	s.NewStrategyBase(fwThread, "broadcast", 1)
+}
+
+// (AI GENERATED DESCRIPTION): Sends a cached Data packet (retrieved from the Content Store) back to the requester via the specified PIT entry, using the requesting face and indicating the Content Store as the data source.
+func (s *Broadcast) AfterContentStoreHit(
+	packet *defn.Pkt,
+	pitEntry table.PitEntry,
+	inFace uint64,
+) {
+	core.Log.Trace(s, "AfterContentStoreHit", "name", packet.Name, "faceid", inFace)
+	s.SendData(packet, pitEntry, inFace, 0) // 0 indicates ContentStore is source
+}
+
+// (AI GENERATED DESCRIPTION): Forwards a received Data packet to every face recorded in the PIT entry, logging each forwarding step and invoking SendData for each destination.
+func (s *Broadcast) AfterReceiveData(
+	packet *defn.Pkt,
+	pitEntry table.PitEntry,
+	inFace uint64,
+) {
+	core.Log.Trace(s, "AfterReceiveData", "name", packet.Name, "inrecords", len(pitEntry.InRecords()))
+	for faceID := range pitEntry.InRecords() {
+		core.Log.Trace(s, "Forwarding Data", "name", packet.Name, "faceid", faceID)
+		s.SendData(packet, pitEntry, faceID, inFace)
+	}
+}
+
+// Forwards an incoming Interest to all next-hops
+func (s *Broadcast) AfterReceiveInterest(
+	packet *defn.Pkt,
+	pitEntry table.PitEntry,
+	inFace uint64,
+	nexthops []*table.FibNextHopEntry,
+	nextER []enc.Name,
+) {
+	if len(nexthops) == 0 {
+		core.Log.Debug(s, "No nexthop found - DROP", "name", packet.Name)
+		return
+	}
+
+	successfulForward := false
+
+	for i, nh := range nexthops {
+		// avoid broadcasting on hops that already have out record
+		// q: should we do this?
+		if oR := pitEntry.OutRecords()[nh.Nexthop]; oR != nil {
+			continue;
+		}
+
+		// if there is an associated EgressRouter tag with this new route, then set packet.EgressRouter to the tag
+		oldEgress := packet.EgressRouter
+		if i < len(nextER) {
+			packet.EgressRouter = nextER[i]
+		}
+
+		if sent := s.SendInterest(packet, pitEntry, nh.Nexthop, inFace); sent {
+			core.Log.Trace(s, "Forwarded Interest", "name", packet.Name, "faceid", nh.Nexthop)
+			successfulForward = true
+		} else {
+			core.Log.Trace(s, "Error forwarding interest", "name", packet.Name, "faceid", nh.Nexthop)
+		}
+
+		packet.EgressRouter = oldEgress
+	}
+
+	if !successfulForward {
+		core.Log.Debug(s, "No usable nexthop for Interest - DROP", "name", packet.Name)
+	}
+}
+
+
+// (AI GENERATED DESCRIPTION): No‑op hook invoked before satisfying an Interest in the Broadcast strategy – it performs no action.
+func (s *Broadcast) BeforeSatisfyInterest(pitEntry table.PitEntry, inFace uint64) {
+	// This does nothing in Broadcast
+}

--- a/fw/fw/broadcast.go
+++ b/fw/fw/broadcast.go
@@ -68,12 +68,6 @@ func (s *Broadcast) AfterReceiveInterest(
 	successfulForward := false
 
 	for i, nh := range nexthops {
-		// avoid broadcasting on hops that already have out record
-		// q: should we do this?
-		if oR := pitEntry.OutRecords()[nh.Nexthop]; oR != nil {
-			continue
-		}
-
 		// if there is an associated EgressRouter tag with this new route, then set packet.EgressRouter to the tag
 		oldEgress := packet.EgressRouter
 		if i < len(nextER) {

--- a/fw/fw/broadcast.go
+++ b/fw/fw/broadcast.go
@@ -67,21 +67,13 @@ func (s *Broadcast) AfterReceiveInterest(
 
 	successfulForward := false
 
-	for i, nh := range nexthops {
-		// if there is an associated EgressRouter tag with this new route, then set packet.EgressRouter to the tag
-		oldEgress := packet.EgressRouter
-		if i < len(nextER) {
-			packet.EgressRouter = nextER[i]
-		}
-
+	for _, nh := range nexthops {
 		if sent := s.SendInterest(packet, pitEntry, nh.Nexthop, inFace); sent {
 			core.Log.Trace(s, "Forwarded Interest", "name", packet.Name, "faceid", nh.Nexthop)
 			successfulForward = true
 		} else {
 			core.Log.Trace(s, "Error forwarding interest", "name", packet.Name, "faceid", nh.Nexthop)
 		}
-
-		packet.EgressRouter = oldEgress
 	}
 
 	if !successfulForward {

--- a/fw/fw/broadcast.go
+++ b/fw/fw/broadcast.go
@@ -71,7 +71,7 @@ func (s *Broadcast) AfterReceiveInterest(
 		// avoid broadcasting on hops that already have out record
 		// q: should we do this?
 		if oR := pitEntry.OutRecords()[nh.Nexthop]; oR != nil {
-			continue;
+			continue
 		}
 
 		// if there is an associated EgressRouter tag with this new route, then set packet.EgressRouter to the tag
@@ -94,7 +94,6 @@ func (s *Broadcast) AfterReceiveInterest(
 		core.Log.Debug(s, "No usable nexthop for Interest - DROP", "name", packet.Name)
 	}
 }
-
 
 // (AI GENERATED DESCRIPTION): No‑op hook invoked before satisfying an Interest in the Broadcast strategy – it performs no action.
 func (s *Broadcast) BeforeSatisfyInterest(pitEntry table.PitEntry, inFace uint64) {

--- a/fw/fw/thread.go
+++ b/fw/fw/thread.go
@@ -252,6 +252,7 @@ func (t *Thread) processIncomingInterest(packet *defn.Pkt) {
 	// Get strategy for name
 	strategyName := table.FibStrategyTable.FindStrategyEnc(interest.Name())
 	strategy := t.strategies[strategyName.Hash()]
+	bestRouteStrategy := t.strategies[defn.BEST_ROUTE_STRATEGY.Hash()]
 
 	// Add in-record and determine if already pending
 	// this looks like custom interest again, but again can be changed without much issue?
@@ -384,6 +385,9 @@ func (t *Thread) processIncomingInterest(packet *defn.Pkt) {
 
 	if len(allowedNetNexthops) > 0 {
 		// Pass to strategy AfterReceiveInterest pipeline
+		if len(packet.EgressRouter) > 0 {
+			strategy = bestRouteStrategy
+		}
 		strategy.AfterReceiveInterest(packet, pitEntry, incomingFace.FaceID(), allowedNetNexthops, allowedNetER)
 	} else {
 		// NACK?


### PR DESCRIPTION
After this PR is merged, #174 should be reviewed (replicast)

---
See `test_005` for e2e test verifying operation.

Adds:
* override to setting the strategy to `best-route` when ER tag is detected (see [slide 16](https://docs.google.com/presentation/d/1tZLJzV2iodtm-lvT1djQ70Ru2P1akBlcaT99Nr-90LY/edit?slide=id.g3bcdcc0ae05_1_220#slide=id.g3bcdcc0ae05_1_220))
* broadcast forwarding strategy to forward interest packet to all faces

Requesting @tianyuan129 review