### PR TITLE
ndncert + nac integration

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -52,6 +52,7 @@ func init() {
 	CmdNDNd.AddCommand(tools.CmdPingServer())
 	CmdNDNd.AddCommand(tools.CmdCatChunks())
 	CmdNDNd.AddCommand(tools.CmdPutChunks())
+	CmdNDNd.AddCommand(tools.CmdNac())
 }
 
 // (AI GENERATED DESCRIPTION): Creates the top‑level “fw” command for managing the NDN Forwarding Daemon, adding a “run” subcommand to start the daemon and a set of “nfdc” control subcommands for configuring it.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -44,6 +44,7 @@ func init() {
 
 	CmdNDNd.AddGroup(&cobra.Group{ID: "sec", Title: "Security Tools"})
 	CmdNDNd.AddCommand(sec.CmdSec())
+	CmdNDNd.AddCommand(sec.CmdCertServer())
 	CmdNDNd.AddCommand(sec.CmdCertCli())
 
 	CmdNDNd.AddGroup(&cobra.Group{ID: "tools", Title: "Debug Tools"})

--- a/std/examples/ndncert/ca.conf.sample
+++ b/std/examples/ndncert/ca.conf.sample
@@ -1,0 +1,33 @@
+{
+  "ca-prefix": "/example",
+  "ca-info": "An example NDNCERT CA",
+  "max-validity-period": "1296000",
+  "max-suffix-length": "2",
+  "probe-parameters": [
+    {
+      "probe-parameter-key": "email"
+    }
+  ],
+  "supported-challenges": [
+    {
+      "challenge": "pin"
+    },
+    {
+      "challenge": "email"
+    }
+  ],
+  "redirect-to": [
+    {
+      "ca-prefix": "/ndn/edu/ucla",
+      "certificate": "Bv0BNQcwCANuZG4IA2VkdQgEdWNsYQgDS0VZCAgAdGt6D7S2VAgEc2VsZggJ/QAAAX5lZMOiFAkYAQIZBAA27oAVWzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABOKmvwHmK5t+MhMPgft4qmKC7YF9I6UM/o7GFa4BjZQknsqLvxdW2zIAF+iPPHJV0eVAijX6bYrQobuomiWZAY0WUBsBAxwhBx8IA25kbggDZWR1CAR1Y2xhCANLRVkICAB0a3oPtLZU/QD9Jv0A/g8xOTcwMDEwMVQwMDAwMDD9AP8PMjA0MjAxMTJUMDAxNjQ5F0cwRQIgBF/HS0j1DMo/dIILv/6IMUmMAhVtS3m97YgS8tsBhC0CIQCgEm0e6KoBCyV6PiueN9YW9zSSkdg8MLCxsyduP8tRsQ==",
+      "policy-type": "email",
+      "policy-param": "g.ucla.edu"
+    },
+    {
+      "ca-prefix": "/ndn/edu/ucla/cs",
+      "certificate": "Bv0BPgc0CANuZG4IA2VkdQgEdWNsYQgCY3MIA0tFWQgI27kFrpVyxUAIBHNlbGYICf0AAAF+ZZ/79xQJGAECGQQANu6AFVswWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASOLtEWMpMk8tPqPe0VY9SAYA0e969NNy5t0QeseNvr6AbYWQHBR4oa6Ymv3TRlQnyy+IzvKPte5suX/Qhtnjn2FlQbAQMcJQcjCANuZG4IA2VkdQgEdWNsYQgCY3MIA0tFWQgI27kFrpVyxUD9AP0m/QD+DzE5NzAwMTAxVDAwMDAwMP0A/w8yMDQyMDExMlQwMTIxMzAXSDBGAiEAm+aJbcmI0n37Qhear5fo//S02ZlDkmao8a7olSsElx8CIQDD8dZkYfD8xcvYl3vXm7G/NSXFrnrRqxC7NR/4r4swbw==",
+      "policy-type": "email",
+      "policy-param": "cs.ucla.edu"
+    }
+  ]
+}

--- a/std/examples/ndncert/ca.conf.sample
+++ b/std/examples/ndncert/ca.conf.sample
@@ -10,10 +10,7 @@
   ],
   "supported-challenges": [
     {
-      "challenge": "pin"
-    },
-    {
-      "challenge": "email"
+      "challenge": "dns"
     }
   ],
   "redirect-to": [

--- a/std/nac/access_manager.go
+++ b/std/nac/access_manager.go
@@ -43,6 +43,10 @@ func (am *AccessManager) Dataset() string {
 	return am.dataset
 }
 
+func (am *AccessManager) KDKID() []byte {
+	return am.kdk.ID
+}
+
 func normalizeKeyName(name string) string {
 	return strings.TrimPrefix(name, "/")
 }

--- a/std/nac/access_manager.go
+++ b/std/nac/access_manager.go
@@ -1,48 +1,55 @@
 package nac
 
-import "crypto/ecdh"
+import (
+	"crypto/ecdh"
+	"strings"
+)
 
-// AccessManager: controls read access for a credential namespace
-// idk if this lives on system controller, producer, or what but there must be some entity that gens the KEK/KDK pair, holds the KDK private keys, allows producers to fetch KEK and consumers to fetch encrpyted KDK
-// it does:
-//   - gens KEK/KDK pair
-//   - publishes KEK openly
-//   - distributes per consumer encrypted KDKs
-//
-// https://named-data.net/wp-content/uploads/2016/02/ndn-0034-2-nac.pdf - 4.4.2 pg 6
+// AccessManager controls read access for a namespace.
+// Generates KEK/KDK pair, publishes KEK openly, distributes per-consumer encrypted KDKs.
+// ref: https://named-data.net/wp-content/uploads/2016/02/ndn-0034-2-nac.pdf - 4.4.2 pg 6
 type AccessManager struct {
-	credentialPrefix string
-	kek              *KeyEncryptionKey
-	kdk              *KeyDecryptionKey
-	members          map[string][]byte // consumer keyname ->encrypted KDK bytes
+	accessPrefix string
+	dataset      string
+	kek          *KeyEncryptionKey
+	kdk          *KeyDecryptionKey
+	members      map[string][]byte // consumer keyname -> encrypted KDK bytes
 }
 
-// NewAccessManager: creates access manager
-func NewAccessManager(credentialPrefix string) (*AccessManager, error) {
+// NewAccessManager creates an access manager for <accessPrefix>/NAC/<dataset>.
+func NewAccessManager(accessPrefix, dataset string) (*AccessManager, error) {
 	kek, kdk, err := NewKeyPair()
 	if err != nil {
 		return nil, err
 	}
 	return &AccessManager{
-		credentialPrefix: credentialPrefix,
-		kek:              kek,
-		kdk:              kdk,
-		members:          make(map[string][]byte),
+		accessPrefix: accessPrefix,
+		dataset:      dataset,
+		kek:          kek,
+		kdk:          kdk,
+		members:      make(map[string][]byte),
 	}, nil
 }
 
-// KEK: returns pub encryption key
 func (am *AccessManager) KEK() *KeyEncryptionKey {
 	return am.kek
 }
 
-// CredentialPrefix: returns NDN credential prefix
-func (am *AccessManager) CredentialPrefix() string {
-	return am.credentialPrefix
+func (am *AccessManager) AccessPrefix() string {
+	return am.accessPrefix
 }
 
-// AddMember: auths a consumer to decrypt content under this credential
+func (am *AccessManager) Dataset() string {
+	return am.dataset
+}
+
+func normalizeKeyName(name string) string {
+	return strings.TrimPrefix(name, "/")
+}
+
+// AddMember authorizes a consumer to decrypt content under this namespace.
 func (am *AccessManager) AddMember(consumerKeyName string, consumerPubKey *ecdh.PublicKey) error {
+	consumerKeyName = normalizeKeyName(consumerKeyName)
 	kdkBytes, err := SerializePrivateKey(am.kdk.PrivateKey)
 	if err != nil {
 		return err
@@ -58,21 +65,19 @@ func (am *AccessManager) AddMember(consumerKeyName string, consumerPubKey *ecdh.
 	return nil
 }
 
-// GetEncryptedKDK: returns encrypted KDK blob for a consumer OR (nil, false) if  unauthorized
+// GetEncryptedKDK returns encrypted KDK blob for a consumer, or (nil, false) if unauthorized.
 func (am *AccessManager) GetEncryptedKDK(consumerKeyName string) ([]byte, bool) {
-	blob, ok := am.members[consumerKeyName]
+	blob, ok := am.members[normalizeKeyName(consumerKeyName)]
 	return blob, ok
 }
 
-// GetEncryptedKDKName: NDN name for a consumer's  KDK packet -> <kdk-name>/FOR/<consumerKeyName>
-// (pg 7)
+// GetEncryptedKDKName: <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<consumer-key-name>
 func (am *AccessManager) GetEncryptedKDKName(consumerKeyName string) string {
-	kdkName := KDKName(am.credentialPrefix, am.kdk.ID)
-	return EncryptedDataName(kdkName, consumerKeyName)
+	return EncryptedKDKName(am.accessPrefix, am.dataset, am.kdk.ID, normalizeKeyName(consumerKeyName))
 }
 
-// IsAuthorized: has a consumer been added as a member?
+// IsAuthorized checks if a consumer has been added as a member.
 func (am *AccessManager) IsAuthorized(consumerKeyName string) bool {
-	_, ok := am.members[consumerKeyName]
+	_, ok := am.members[normalizeKeyName(consumerKeyName)]
 	return ok
 }

--- a/std/nac/access_manager.go
+++ b/std/nac/access_manager.go
@@ -1,0 +1,78 @@
+package nac
+
+import "crypto/ecdh"
+
+// AccessManager: controls read access for a credential namespace
+// idk if this lives on system controller, producer, or what but there must be some entity that gens the KEK/KDK pair, holds the KDK private keys, allows producers to fetch KEK and consumers to fetch encrpyted KDK
+// it does:
+//   - gens KEK/KDK pair
+//   - publishes KEK openly
+//   - distributes per consumer encrypted KDKs
+//
+// https://named-data.net/wp-content/uploads/2016/02/ndn-0034-2-nac.pdf - 4.4.2 pg 6
+type AccessManager struct {
+	credentialPrefix string
+	kek              *KeyEncryptionKey
+	kdk              *KeyDecryptionKey
+	members          map[string][]byte // consumer keyname ->encrypted KDK bytes
+}
+
+// NewAccessManager: creates access manager
+func NewAccessManager(credentialPrefix string) (*AccessManager, error) {
+	kek, kdk, err := NewKeyPair()
+	if err != nil {
+		return nil, err
+	}
+	return &AccessManager{
+		credentialPrefix: credentialPrefix,
+		kek:              kek,
+		kdk:              kdk,
+		members:          make(map[string][]byte),
+	}, nil
+}
+
+// KEK: returns pub encryption key
+func (am *AccessManager) KEK() *KeyEncryptionKey {
+	return am.kek
+}
+
+// CredentialPrefix: returns NDN credential prefix
+func (am *AccessManager) CredentialPrefix() string {
+	return am.credentialPrefix
+}
+
+// AddMember: auths a consumer to decrypt content under this credential
+func (am *AccessManager) AddMember(consumerKeyName string, consumerPubKey *ecdh.PublicKey) error {
+	kdkBytes, err := SerializePrivateKey(am.kdk.PrivateKey)
+	if err != nil {
+		return err
+	}
+
+	// ECIES-encrypt w/ consumers pub key
+	encKDK, err := AsymEncrypt(consumerPubKey, kdkBytes)
+	if err != nil {
+		return err
+	}
+	// fmt.Printf("added member %s, encKDK len=%d\n", consumerKeyName, len(encKDK))
+	am.members[consumerKeyName] = encKDK
+	return nil
+}
+
+// GetEncryptedKDK: returns encrypted KDK blob for a consumer OR (nil, false) if  unauthorized
+func (am *AccessManager) GetEncryptedKDK(consumerKeyName string) ([]byte, bool) {
+	blob, ok := am.members[consumerKeyName]
+	return blob, ok
+}
+
+// GetEncryptedKDKName: NDN name for a consumer's  KDK packet -> <kdk-name>/FOR/<consumerKeyName>
+// (pg 7)
+func (am *AccessManager) GetEncryptedKDKName(consumerKeyName string) string {
+	kdkName := KDKName(am.credentialPrefix, am.kdk.ID)
+	return EncryptedDataName(kdkName, consumerKeyName)
+}
+
+// IsAuthorized: has a consumer been added as a member?
+func (am *AccessManager) IsAuthorized(consumerKeyName string) bool {
+	_, ok := am.members[consumerKeyName]
+	return ok
+}

--- a/std/nac/consumer.go
+++ b/std/nac/consumer.go
@@ -1,0 +1,100 @@
+package nac
+
+import (
+	"crypto/ecdh"
+	"fmt"
+	"time"
+
+	enc "github.com/named-data/ndnd/std/encoding"
+	"github.com/named-data/ndnd/std/ndn"
+	"github.com/named-data/ndnd/std/types/optional"
+)
+
+// Consumer fetches NAC keys over NDN and decrypts content.
+type Consumer struct {
+	engine          ndn.Engine
+	consumerKeyName string
+	privateKey      *ecdh.PrivateKey
+	decryptor       *Decryptor
+}
+
+// NewConsumer creates a NAC consumer that can fetch keys and decrypt content.
+func NewConsumer(engine ndn.Engine, consumerKeyName string, privateKey *ecdh.PrivateKey) *Consumer {
+	return &Consumer{
+		engine:          engine,
+		consumerKeyName: consumerKeyName,
+		privateKey:      privateKey,
+		decryptor:       NewDecryptor(consumerKeyName, privateKey),
+	}
+}
+
+// FetchKEK fetches the public Key Encryption Key from the network.
+// kekName is the full NDN name: <credential-prefix>/E-KEY/<key-id>
+func (c *Consumer) FetchKEK(kekName string) (*KeyEncryptionKey, error) {
+	name, err := enc.NameFromStr(kekName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid KEK name: %w", err)
+	}
+
+	ch := make(chan ndn.ExpressCallbackArgs, 1)
+	interest, err := c.engine.Spec().MakeInterest(name, &ndn.InterestConfig{
+		CanBePrefix: true,
+		Lifetime:    optional.Some(4 * time.Second),
+	}, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make KEK interest: %w", err)
+	}
+
+	c.engine.Express(interest, func(args ndn.ExpressCallbackArgs) { ch <- args })
+	args := <-ch
+
+	if args.Result != ndn.InterestResultData {
+		return nil, fmt.Errorf("failed to fetch KEK: %s", args.Result)
+	}
+
+	pubKeyBytes := args.Data.Content().Join()
+	pubKey, err := DeserializePublicKey(pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid KEK public key: %w", err)
+	}
+
+	return &KeyEncryptionKey{
+		PublicKey: pubKey,
+	}, nil
+}
+
+// FetchEncryptedKDK fetches the encrypted KDK for this consumer from the network.
+// kdkForName is: <kdk-name>/FOR/<consumer-key-name>
+func (c *Consumer) FetchEncryptedKDK(kdkForName string) ([]byte, error) {
+	name, err := enc.NameFromStr(kdkForName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid KDK name: %w", err)
+	}
+
+	ch := make(chan ndn.ExpressCallbackArgs, 1)
+	interest, err := c.engine.Spec().MakeInterest(name, &ndn.InterestConfig{
+		CanBePrefix: true,
+		Lifetime:    optional.Some(4 * time.Second),
+	}, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make KDK interest: %w", err)
+	}
+
+	c.engine.Express(interest, func(args ndn.ExpressCallbackArgs) { ch <- args })
+	args := <-ch
+
+	if args.Result != ndn.InterestResultData {
+		return nil, fmt.Errorf("failed to fetch encrypted KDK: %s", args.Result)
+	}
+
+	return args.Data.Content().Join(), nil
+}
+
+// Decrypt decrypts content using the full NAC chain, fetching keys from network as needed.
+func (c *Consumer) Decrypt(
+	encContent *EncryptedContent,
+	encCK *EncryptedCK,
+	encKDKBlob []byte,
+) ([]byte, error) {
+	return c.decryptor.Decrypt(encContent, encCK, encKDKBlob)
+}

--- a/std/nac/consumer.go
+++ b/std/nac/consumer.go
@@ -8,6 +8,7 @@ import (
 	enc "github.com/named-data/ndnd/std/encoding"
 	"github.com/named-data/ndnd/std/ndn"
 	"github.com/named-data/ndnd/std/types/optional"
+	"github.com/named-data/ndnd/std/utils"
 )
 
 // Consumer fetches NAC keys over NDN and decrypts content.
@@ -38,8 +39,8 @@ func (c *Consumer) FetchKEK(kekName string) (*KeyEncryptionKey, error) {
 
 	ch := make(chan ndn.ExpressCallbackArgs, 1)
 	interest, err := c.engine.Spec().MakeInterest(name, &ndn.InterestConfig{
-		CanBePrefix: true,
-		Lifetime:    optional.Some(4 * time.Second),
+		Lifetime: optional.Some(4 * time.Second),
+		Nonce:    utils.ConvertNonce(c.engine.Timer().Nonce()),
 	}, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make KEK interest: %w", err)
@@ -73,8 +74,8 @@ func (c *Consumer) FetchEncryptedKDK(kdkForName string) ([]byte, error) {
 
 	ch := make(chan ndn.ExpressCallbackArgs, 1)
 	interest, err := c.engine.Spec().MakeInterest(name, &ndn.InterestConfig{
-		CanBePrefix: true,
-		Lifetime:    optional.Some(4 * time.Second),
+		Lifetime: optional.Some(4 * time.Second),
+		Nonce:    utils.ConvertNonce(c.engine.Timer().Nonce()),
 	}, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make KDK interest: %w", err)

--- a/std/nac/consumer.go
+++ b/std/nac/consumer.go
@@ -30,7 +30,7 @@ func NewConsumer(engine ndn.Engine, consumerKeyName string, privateKey *ecdh.Pri
 }
 
 // FetchKEK fetches the public Key Encryption Key from the network.
-// kekName is the full NDN name: <credential-prefix>/E-KEY/<key-id>
+// kekName: <access-prefix>/NAC/<dataset>/KEK/<key-id>
 func (c *Consumer) FetchKEK(kekName string) (*KeyEncryptionKey, error) {
 	name, err := enc.NameFromStr(kekName)
 	if err != nil {
@@ -65,7 +65,7 @@ func (c *Consumer) FetchKEK(kekName string) (*KeyEncryptionKey, error) {
 }
 
 // FetchEncryptedKDK fetches the encrypted KDK for this consumer from the network.
-// kdkForName is: <kdk-name>/FOR/<consumer-key-name>
+// kdkForName: <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<consumer-key-name>
 func (c *Consumer) FetchEncryptedKDK(kdkForName string) ([]byte, error) {
 	name, err := enc.NameFromStr(kdkForName)
 	if err != nil {

--- a/std/nac/crypto.go
+++ b/std/nac/crypto.go
@@ -1,0 +1,178 @@
+package nac
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// info string for HKDF - needs to match on encrypt/decrypt
+// "optional but highly recommended input that serves to bind the derived key material to specific application and context information"
+// https://crypto.stackexchange.com/questions/6553/what-information-to-include-is-the-info-input-for-hkdf#:~:text=While%20the%20'info'%20value%20is,input%20key%20material%20value%20IKM.
+var hkdfInfo = []byte("NAC-ECIES-v1")
+
+// SymEncrypt: encrypts plaintext with AES-256-GCM
+// key must be exactly 32 bytes (bc 256 bits)
+// returns: (below is concat return)
+//
+//	[12-byte nonce][ciphertext][16-byte GCM auth tag]
+//
+// ref: https://pkg.go.dev/crypto/cipher#NewGCM
+func SymEncrypt(key, plaintext []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("key must be 32 bytes, got %d", len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	// fresh nonce for fresh encryption
+	nonce := make([]byte, gcm.NonceSize()) // 12 bytes
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("nonce generation failed: %w", err)
+	}
+
+	// Note: gcm.Seal appends ciphertext+tag to dst ==> passing nonce as dst the nonce gets prepended to the output
+	// result:
+	//
+	// 			[nonce][ciphertext][tag]
+	//
+	// ref: https://pkg.go.dev/crypto/cipher#AEAD.Seal
+	out := gcm.Seal(nonce, nonce, plaintext, nil)
+	return out, nil
+}
+
+// SymDecrypt: decrypt AES-256-GCM ciphertex, key should be 32 bytes, ciphertext must be output of SymEncrypt (nonce + encrypted data + tag)
+func SymDecrypt(key, ciphertext []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("key must be 32 bytes, got %d", len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := gcm.NonceSize() // 12
+	if len(ciphertext) < nonceSize+gcm.Overhead() {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce := ciphertext[:nonceSize]
+	enc := ciphertext[nonceSize:]
+
+	plaintext, err := gcm.Open(nil, nonce, enc, nil)
+	if err != nil {
+		// gcm auth tag verification failed == data tampered/wrong key
+		return nil, fmt.Errorf("decryption failed: %w", err)
+	}
+	return plaintext, nil
+}
+
+// AsymEncrypt: encrypts plaintext w/ ECIES (X25519 +HKDF + AES-GCM)
+//
+//	pub: recipient's X25519 pub key
+//	plaintext: arbitrary length data to encrypt
+//
+// ECIES will (https://en.wikipedia.org/wiki/Integrated_Encryption_Scheme):
+//  1. gen ephemeral X25519 key pair
+//  2. ECDH(ephemeral private, recipient public) -> shared secret
+//  3. HKDF(shared secret) -> 32-byte AES key
+//  4. SymEncrypt(plaintext) using derived AES key
+//  5. return: [32-byte ephemeral public key][encrypted data]
+//
+// output:
+//
+//	[ephemeral_pub_key][nonce+ciphertext+tag from SymEncrypt]
+func AsymEncrypt(pub *ecdh.PublicKey, plaintext []byte) ([]byte, error) {
+	// generate ephemeral key pair
+	curve := ecdh.X25519()
+	ephemeralPriv, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ephemeral key: %w", err)
+	}
+	ephemeralPub := ephemeralPriv.PublicKey()
+
+	// ECDH  get shared secret
+	sharedSecret, err := ephemeralPriv.ECDH(pub)
+	if err != nil {
+		return nil, fmt.Errorf("ECDH failed: %w", err)
+	}
+
+	// AES key from shared secret using HKDF
+	//https://pkg.go.dev/golang.org/x/crypto/hkdf
+	kdf := hkdf.New(sha256.New, sharedSecret, nil, hkdfInfo)
+	aesKey := make([]byte, 32)
+	if _, err := io.ReadFull(kdf, aesKey); err != nil {
+		return nil, fmt.Errorf("HKDF failed: %w", err)
+	}
+	// encrypt plaintext
+	encData, err := SymEncrypt(aesKey, plaintext)
+	if err != nil {
+		return nil, err
+	}
+
+	// prepend pub key to ciphertext
+	result := append(ephemeralPub.Bytes(), encData...)
+	return result, nil
+}
+
+// AsymDecrypt: decrypts ECIES ciphertext
+//
+//	priv: recipient's X25519 private key
+//	ciphertext: output from AsymEncrypt
+//
+// ...basically just reverse of AsymEncrypt:
+//  1. get first 32 bytes (ephemeral pub key)
+//  2. ECDH(recipient private, ephemeral public) -> shared secret
+//  3. HKDF(shared secret) -> AES key
+//  4. SymDecrypt(remaining bytes) w/ AES key
+func AsymDecrypt(priv *ecdh.PrivateKey, ciphertext []byte) ([]byte, error) {
+	// get public key
+	if len(ciphertext) < 32 {
+		return nil, fmt.Errorf("ciphertext too short (need at least 32 bytes for ephemeral key)")
+	}
+	ephemeralPubBytes := ciphertext[:32]
+	encData := ciphertext[32:]
+	curve := ecdh.X25519()
+	ephemeralPub, err := curve.NewPublicKey(ephemeralPubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ephemeral public key: %w", err)
+	}
+
+	// get shared secret (should be same as what encrypt got)
+	sharedSecret, err := priv.ECDH(ephemeralPub)
+	if err != nil {
+		return nil, fmt.Errorf("ECDH failed: %w", err)
+	}
+
+	// get AES key from shared secret w/ HKDF
+	// NOTE: must use same parameters as AsymEncrypt (nil is the salt, info=hkdfInfo)
+	kdf := hkdf.New(sha256.New, sharedSecret, nil, hkdfInfo)
+	aesKey := make([]byte, 32)
+	if _, err := io.ReadFull(kdf, aesKey); err != nil {
+		return nil, fmt.Errorf("HKDF failed: %w", err)
+	}
+	// fmt.Printf("derived aes key len=%d\n", len(aesKey))
+
+	// decrypt data w/ AES key
+	plaintext, err := SymDecrypt(aesKey, encData)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
+}

--- a/std/nac/decryptor.go
+++ b/std/nac/decryptor.go
@@ -1,0 +1,74 @@
+package nac
+
+import (
+	"crypto/ecdh"
+	"fmt"
+)
+
+// Decryptor: chain is
+//
+//	encKDK blob  ->  AsymDecrypt(consumer key)  ->  KDK
+//	encCK payload  ->  AsymDecrypt(KDK)  ->  CK (32 byte AES key)
+//	encContent payload  ->  SymDecrypt(CK)  ->  plaintext
+type Decryptor struct {
+	consumerKeyName string           // consumer's NDN identity name
+	privateKey      *ecdh.PrivateKey // consumer's X25519 private key
+}
+
+// NewDecryptor: creates decryptor for a consumer
+func NewDecryptor(consumerKeyName string, privateKey *ecdh.PrivateKey) *Decryptor {
+	return &Decryptor{
+		consumerKeyName: consumerKeyName,
+		privateKey:      privateKey,
+	}
+}
+
+// Decrypt: runs full decryption chain (fig 13)
+//
+//	(encContent+encCK would be fetched via NDN Interests, encKDKBlob from access manager)
+func (d *Decryptor) Decrypt(
+	encContent *EncryptedContent,
+	encCK *EncryptedCK,
+	encKDKBlob []byte,
+) ([]byte, error) {
+	// decrypt KDK w/ consumer's private key
+	kdkBytes, err := AsymDecrypt(d.privateKey, encKDKBlob)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt KDK: %w", err)
+	}
+
+	// deserialize KDK -> X25519 private key
+	kdk, err := DeserializePrivateKey(kdkBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize KDK: %w", err)
+	}
+	// fmt.Printf("KDK, len=%d\n", len(kdkBytes))
+
+	// decrypt content key w/ KDK
+	ckKey, err := AsymDecrypt(kdk, encCK.EncryptedPayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt CK: %w", err)
+	}
+	// fmt.Printf("CK, len=%d\n", len(ckKey))
+	// decrypt content w/ CK
+	plaintext, err := SymDecrypt(ckKey, encContent.EncryptedPayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt content: %w", err)
+	}
+	return plaintext, nil
+}
+
+// CKNameFromContent: gets CK name from encrypted content packet
+//
+//	consumer uses this to build the Interest for fetching the encrypted CK
+func CKNameFromContent(encContent *EncryptedContent) (string, error) {
+	_, ckName, err := ParseEncryptedDataName(encContent.Name)
+	return ckName, err
+}
+
+// KDKNameForConsumer: constructs NDN name of the encrypted KDK this consumer should fetch
+// result: <kdk-name>/FOR/<consumer-key-name>
+func (d *Decryptor) KDKNameForConsumer(credentialPrefix string, kdkKeyID []byte) string {
+	kdkName := KDKName(credentialPrefix, kdkKeyID)
+	return EncryptedDataName(kdkName, d.consumerKeyName)
+}

--- a/std/nac/decryptor.go
+++ b/std/nac/decryptor.go
@@ -58,17 +58,8 @@ func (d *Decryptor) Decrypt(
 	return plaintext, nil
 }
 
-// CKNameFromContent: gets CK name from encrypted content packet
-//
-//	consumer uses this to build the Interest for fetching the encrypted CK
-func CKNameFromContent(encContent *EncryptedContent) (string, error) {
-	_, ckName, err := ParseEncryptedDataName(encContent.Name)
-	return ckName, err
-}
-
-// KDKNameForConsumer: constructs NDN name of the encrypted KDK this consumer should fetch
-// result: <kdk-name>/FOR/<consumer-key-name>
-func (d *Decryptor) KDKNameForConsumer(credentialPrefix string, kdkKeyID []byte) string {
-	kdkName := KDKName(credentialPrefix, kdkKeyID)
-	return EncryptedDataName(kdkName, d.consumerKeyName)
+// KDKNameForConsumer constructs the encrypted KDK name this consumer should fetch:
+// <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<consumer-key-name>
+func (d *Decryptor) KDKNameForConsumer(accessPrefix, dataset string, kdkKeyID []byte) string {
+	return EncryptedKDKName(accessPrefix, dataset, kdkKeyID, d.consumerKeyName)
 }

--- a/std/nac/encryptor.go
+++ b/std/nac/encryptor.go
@@ -1,0 +1,64 @@
+package nac
+
+// EncryptedContent: encrypted content packet
+type EncryptedContent struct {
+	Name             string // <content-name>/FOR/<ck-name>
+	EncryptedPayload []byte // output of SymEncrypt(ck, plaintext)
+}
+
+// EncryptedCK: encrypted content key packet
+type EncryptedCK struct {
+	Name             string // <ck-name>/FOR/<kek-name>
+	EncryptedPayload []byte // output of AsymEncrypt(kek, ck.Key)
+}
+
+// Encryptor: producer side encryption, takes plaintext+KEK, produces encrypted content + encrypted CK
+
+type Encryptor struct {
+	dataPrefix string            // /alice/samples/documents
+	credPrefix string            // /alice/read/documents
+	kek        *KeyEncryptionKey // fetched from access manager (via NDN Interest)
+}
+
+// NewEncryptor: creates encryptor, kek is passed directly for now (fetched via Interest)
+func NewEncryptor(dataPrefix, credentialPrefix string, kek *KeyEncryptionKey) *Encryptor {
+	return &Encryptor{
+		dataPrefix: dataPrefix,
+		credPrefix: credentialPrefix,
+		kek:        kek,
+	}
+}
+
+// Encrypt: encrypts content item, generates fresh CK
+func (e *Encryptor) Encrypt(contentName string, plaintext []byte) (*EncryptedContent, *EncryptedCK, error) {
+	ck, err := NewContentKey()
+	if err != nil {
+		return nil, nil, err
+	}
+	// encrypt content
+	encPayload, err := SymEncrypt(ck.Key, plaintext)
+	if err != nil {
+		return nil, nil, err
+	}
+	// build encrypted content packet
+	ckName := ContentKeyName(e.dataPrefix, ck.ID)
+	// fmt.Printf("ckName=%s contentName=%s\n", ckName, contentName)
+	encContent := &EncryptedContent{
+		Name:             EncryptedDataName(contentName, ckName),
+		EncryptedPayload: encPayload,
+	}
+
+	encCKPayload, err := AsymEncrypt(e.kek.PublicKey, ck.Key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// build encrypted CK packet
+	kekName := KEKName(e.credPrefix, e.kek.ID)
+	encCK := &EncryptedCK{
+		Name:             EncryptedDataName(ckName, kekName),
+		EncryptedPayload: encCKPayload,
+	}
+
+	return encContent, encCK, nil
+}

--- a/std/nac/encryptor.go
+++ b/std/nac/encryptor.go
@@ -1,50 +1,47 @@
 package nac
 
-// EncryptedContent: encrypted content packet
 type EncryptedContent struct {
-	Name             string // <content-name>/FOR/<ck-name>
-	EncryptedPayload []byte // output of SymEncrypt(ck, plaintext)
+	CKName           string // CK name for discovery (will be embedded in TLV later)
+	EncryptedPayload []byte // SymEncrypt(ck, plaintext)
 }
 
-// EncryptedCK: encrypted content key packet
 type EncryptedCK struct {
-	Name             string // <ck-name>/FOR/<kek-name>
-	EncryptedPayload []byte // output of AsymEncrypt(kek, ck.Key)
+	Name             string // <data-prefix>/CK/<ck-id>/ENCRYPTED-BY/<kek-name>
+	EncryptedPayload []byte // AsymEncrypt(kek, ck.Key)
 }
 
-// Encryptor: producer side encryption, takes plaintext+KEK, produces encrypted content + encrypted CK
-
+// Encryptor: producer-side encryption using NAC key hierarchy.
 type Encryptor struct {
-	dataPrefix string            // /alice/samples/documents
-	credPrefix string            // /alice/read/documents
-	kek        *KeyEncryptionKey // fetched from access manager (via NDN Interest)
+	dataPrefix   string
+	accessPrefix string
+	dataset      string
+	kek          *KeyEncryptionKey
 }
 
-// NewEncryptor: creates encryptor, kek is passed directly for now (fetched via Interest)
-func NewEncryptor(dataPrefix, credentialPrefix string, kek *KeyEncryptionKey) *Encryptor {
+func NewEncryptor(dataPrefix, accessPrefix, dataset string, kek *KeyEncryptionKey) *Encryptor {
 	return &Encryptor{
-		dataPrefix: dataPrefix,
-		credPrefix: credentialPrefix,
-		kek:        kek,
+		dataPrefix:   dataPrefix,
+		accessPrefix: accessPrefix,
+		dataset:      dataset,
+		kek:          kek,
 	}
 }
 
-// Encrypt: encrypts content item, generates fresh CK
+// Encrypt encrypts content, generating a fresh CK per invocation.
 func (e *Encryptor) Encrypt(contentName string, plaintext []byte) (*EncryptedContent, *EncryptedCK, error) {
 	ck, err := NewContentKey()
 	if err != nil {
 		return nil, nil, err
 	}
-	// encrypt content
+
 	encPayload, err := SymEncrypt(ck.Key, plaintext)
 	if err != nil {
 		return nil, nil, err
 	}
-	// build encrypted content packet
+
 	ckName := ContentKeyName(e.dataPrefix, ck.ID)
-	// fmt.Printf("ckName=%s contentName=%s\n", ckName, contentName)
 	encContent := &EncryptedContent{
-		Name:             EncryptedDataName(contentName, ckName),
+		CKName:           ckName,
 		EncryptedPayload: encPayload,
 	}
 
@@ -53,10 +50,9 @@ func (e *Encryptor) Encrypt(contentName string, plaintext []byte) (*EncryptedCon
 		return nil, nil, err
 	}
 
-	// build encrypted CK packet
-	kekName := KEKName(e.credPrefix, e.kek.ID)
+	kekName := KEKName(e.accessPrefix, e.dataset, e.kek.ID)
 	encCK := &EncryptedCK{
-		Name:             EncryptedDataName(ckName, kekName),
+		Name:             CKEncryptedName(e.dataPrefix, ck.ID, kekName),
 		EncryptedPayload: encCKPayload,
 	}
 

--- a/std/nac/keys.go
+++ b/std/nac/keys.go
@@ -1,0 +1,114 @@
+package nac
+
+import (
+	"crypto/ecdh"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+// ContentKey: symmetric key to encrypt actual file content w/ a fresh one generated for each file
+type ContentKey struct {
+	ID  []byte // 16 random bytes which becomes part of the NDN name
+	Key []byte // 32-byte AES-256 key
+}
+
+// KeyEncryptionKey: X25519 pub key tobe published by Access Manager, producers fetch this so they can wrap Content Keys w/ ECIES
+// NOTE: NDN name pattern is /<credential-prefix>/E-KEY/<hex(ID)>
+// https://named-data.net/wp-content/uploads/2016/02/ndn-0034-2-nac.pdf - pg 6
+type KeyEncryptionKey struct {
+	ID        []byte          // 16 random bytes
+	PublicKey *ecdh.PublicKey // 32 byte X25519 pub key
+}
+
+// KeyDecryptionKey: X25519 private key held by the Access Manager, NEVER published in plaintext (encrypted per-consumer w/ AsymEncrypt (ECIES))
+// NDN name pattern: /<credential-prefix>/D-KEY/<hex(ID)>
+// https://named-data.net/wp-content/uploads/2016/02/ndn-0034-2-nac.pdf - pg 6
+type KeyDecryptionKey struct {
+	ID         []byte           // same ID as corresponding KEK
+	PrivateKey *ecdh.PrivateKey // 32 byte X25519 private key
+}
+
+// NewContentKey: generates fresh Content Key with random ID + key material
+func NewContentKey() (*ContentKey, error) {
+	id := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, id); err != nil {
+		return nil, fmt.Errorf("failed to generate content key ID: %w", err)
+	}
+	key := make([]byte, 32) // AES-256 needs 32 bytes
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("couldn't generate content key: %w", err)
+	}
+
+	return &ContentKey{
+		ID:  id,
+		Key: key,
+	}, nil
+}
+
+// NewKeyPair: generates X25519 key pair and wraps as KEK+KDK, both share the same ID
+func NewKeyPair() (*KeyEncryptionKey, *KeyDecryptionKey, error) {
+	// gen X25519 key pair
+	curve := ecdh.X25519()
+	privateKey, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate X25519 key pair: %w", err)
+	}
+
+	// gen random ID (shared by KEK+KDK)
+	id := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, id); err != nil {
+		return nil, nil, fmt.Errorf("failed to generate key ID: %w", err)
+	}
+
+	kek := &KeyEncryptionKey{
+		ID:        id,
+		PublicKey: privateKey.PublicKey(),
+	}
+	kdk := &KeyDecryptionKey{
+		ID:         id,
+		PrivateKey: privateKey,
+	}
+
+	return kek, kdk, nil
+}
+
+// TODO: remove
+// SerializePublicKey: encodes X25519 pub key to bytes (32 bytes) (this is a noop leftover from RSA impl, X25519 is alr 32B) - use this when publishing KEK as an NDN Data packet
+func SerializePublicKey(pub *ecdh.PublicKey) ([]byte, error) {
+	return pub.Bytes(), nil
+}
+
+// DeserializePublicKey: decode bytes to X25519 pub key
+func DeserializePublicKey(keyBytes []byte) (*ecdh.PublicKey, error) {
+	if len(keyBytes) != 32 {
+		return nil, fmt.Errorf("invalid public key length: got %d bytes, expected 32", len(keyBytes))
+	}
+	curve := ecdh.X25519()
+	pub, err := curve.NewPublicKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid X25519 public key: %w", err)
+	}
+	return pub, nil
+}
+
+// SerializePrivateKey: encode a X25519 private key to bytes (32 bytes) (this is a noop leftover from RSA impl, X25519 is alr 32B) - idea was to use this before AsymEncrypt when distributing KDK to consumers
+func SerializePrivateKey(priv *ecdh.PrivateKey) ([]byte, error) {
+	return priv.Bytes(), nil
+}
+
+// DeserializePrivateKey: decode bytes to X25519 private key
+func DeserializePrivateKey(keyBytes []byte) (*ecdh.PrivateKey, error) {
+	if len(keyBytes) != 32 {
+		return nil, fmt.Errorf("invalid private key length: got %d bytes, expected 32", len(keyBytes))
+	}
+	curve := ecdh.X25519()
+	priv, err := curve.NewPrivateKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid X25519 private key: %w", err)
+	}
+	return priv, nil
+}
+
+// TODO: do we need to convert keys -> hex for NDN names later??
+// 		later we'll want ot build ndn names we should prob be using hex instead of raw bytes...

--- a/std/nac/keys.go
+++ b/std/nac/keys.go
@@ -13,17 +13,16 @@ type ContentKey struct {
 	Key []byte // 32-byte AES-256 key
 }
 
-// KeyEncryptionKey: X25519 pub key tobe published by Access Manager, producers fetch this so they can wrap Content Keys w/ ECIES
-// NOTE: NDN name pattern is /<credential-prefix>/E-KEY/<hex(ID)>
-// https://named-data.net/wp-content/uploads/2016/02/ndn-0034-2-nac.pdf - pg 6
+// KeyEncryptionKey: X25519 pub key published by Access Manager, producers fetch to wrap Content Keys via ECIES.
+// NDN name: <access-prefix>/NAC/<dataset>/KEK/<hex(ID)>
 type KeyEncryptionKey struct {
 	ID        []byte          // 16 random bytes
 	PublicKey *ecdh.PublicKey // 32 byte X25519 pub key
 }
 
-// KeyDecryptionKey: X25519 private key held by the Access Manager, NEVER published in plaintext (encrypted per-consumer w/ AsymEncrypt (ECIES))
-// NDN name pattern: /<credential-prefix>/D-KEY/<hex(ID)>
-// https://named-data.net/wp-content/uploads/2016/02/ndn-0034-2-nac.pdf - pg 6
+// KeyDecryptionKey: X25519 private key held by the Access Manager, never published plaintext.
+// Encrypted per-consumer via ECIES and served at:
+// <access-prefix>/NAC/<dataset>/KDK/<hex(ID)>/ENCRYPTED-BY/<member-key-name>
 type KeyDecryptionKey struct {
 	ID         []byte           // same ID as corresponding KEK
 	PrivateKey *ecdh.PrivateKey // 32 byte X25519 private key

--- a/std/nac/nac_test.go
+++ b/std/nac/nac_test.go
@@ -81,7 +81,7 @@ func TestAsymEncryptDecrypt(t *testing.T) {
 
 func TestFullEncryptionChain(t *testing.T) {
 	// Setup: Access Manager generates KEK/KDK
-	am, err := NewAccessManager("/test/read/docs")
+	am, err := NewAccessManager("/test", "docs")
 	if err != nil {
 		t.Fatalf("NewAccessManager failed: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestFullEncryptionChain(t *testing.T) {
 	}
 
 	// Producer encrypts content
-	encryptor := NewEncryptor("/test/data", "/test/read/docs", am.KEK())
+	encryptor := NewEncryptor("/test/data", "/test", "docs", am.KEK())
 	plaintext := []byte("This is a secret document that only authorized consumers can read.")
 
 	encContent, encCK, err := encryptor.Encrypt("/test/data/doc1", plaintext)
@@ -125,7 +125,7 @@ func TestFullEncryptionChain(t *testing.T) {
 }
 
 func TestUnauthorizedConsumer(t *testing.T) {
-	am, _ := NewAccessManager("/test/read/docs")
+	am, _ := NewAccessManager("/test", "docs")
 
 	// Unauthorized consumer
 	_, ok := am.GetEncryptedKDK("/test/eve/KEY/xyz")
@@ -139,7 +139,7 @@ func TestUnauthorizedConsumer(t *testing.T) {
 }
 
 func TestMultipleConsumers(t *testing.T) {
-	am, _ := NewAccessManager("/test/read/docs")
+	am, _ := NewAccessManager("/test", "docs")
 
 	curve := ecdh.X25519()
 
@@ -160,7 +160,7 @@ func TestMultipleConsumers(t *testing.T) {
 	}
 
 	// Encrypt
-	encryptor := NewEncryptor("/test/data", "/test/read/docs", am.KEK())
+	encryptor := NewEncryptor("/test/data", "/test", "docs", am.KEK())
 	plaintext := []byte("shared secret")
 	encContent, encCK, _ := encryptor.Encrypt("/test/data/doc1", plaintext)
 
@@ -205,14 +205,19 @@ func TestMultipleConsumers(t *testing.T) {
 }
 
 func TestNaming(t *testing.T) {
-	kekName := KEKName("/alice/read/docs", []byte{0x01, 0x02})
-	if kekName != "/alice/read/docs/E-KEY/0102" {
+	kekName := KEKName("/alice", "docs", []byte{0x01, 0x02})
+	if kekName != "/alice/NAC/docs/KEK/0102" {
 		t.Errorf("Unexpected KEK name: %s", kekName)
 	}
 
-	kdkName := KDKName("/alice/read/docs", []byte{0x01, 0x02})
-	if kdkName != "/alice/read/docs/D-KEY/0102" {
+	kdkName := KDKName("/alice", "docs", []byte{0x01, 0x02})
+	if kdkName != "/alice/NAC/docs/KDK/0102" {
 		t.Errorf("Unexpected KDK name: %s", kdkName)
+	}
+
+	encKdkName := EncryptedKDKName("/alice", "docs", []byte{0x01, 0x02}, "/bob/KEY/b1")
+	if encKdkName != "/alice/NAC/docs/KDK/0102/ENCRYPTED-BY/bob/KEY/b1" {
+		t.Errorf("Unexpected encrypted KDK name: %s", encKdkName)
 	}
 
 	ckName := ContentKeyName("/alice/data", []byte{0xAB, 0xCD})
@@ -220,19 +225,19 @@ func TestNaming(t *testing.T) {
 		t.Errorf("Unexpected CK name: %s", ckName)
 	}
 
-	encName := EncryptedDataName("/alice/data/doc1", "/alice/data/CK/abcd")
-	if encName != "/alice/data/doc1/FOR//alice/data/CK/abcd" {
-		t.Errorf("Unexpected encrypted data name: %s", encName)
+	ckEncName := CKEncryptedName("/alice/data", []byte{0xAB, 0xCD}, kekName)
+	if ckEncName != "/alice/data/CK/abcd/ENCRYPTED-BY/alice/NAC/docs/KEK/0102" {
+		t.Errorf("Unexpected CK encrypted name: %s", ckEncName)
 	}
 
-	content, key, err := ParseEncryptedDataName(encName)
+	base, key, err := ParseEncryptedByName(encKdkName)
 	if err != nil {
-		t.Fatalf("ParseEncryptedDataName failed: %v", err)
+		t.Fatalf("ParseEncryptedByName failed: %v", err)
 	}
-	if content != "/alice/data/doc1" {
-		t.Errorf("Unexpected content name: %s", content)
+	if base != "/alice/NAC/docs/KDK/0102" {
+		t.Errorf("Unexpected base name: %s", base)
 	}
-	if key != "/alice/data/CK/abcd" {
+	if key != "bob/KEY/b1" {
 		t.Errorf("Unexpected key name: %s", key)
 	}
 }

--- a/std/nac/nac_test.go
+++ b/std/nac/nac_test.go
@@ -1,0 +1,263 @@
+package nac
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"crypto/rand"
+	"testing"
+)
+
+func TestNewKeyPair(t *testing.T) {
+	kek, kdk, err := NewKeyPair()
+	if err != nil {
+		t.Fatalf("NewKeyPair failed: %v", err)
+	}
+	if !bytes.Equal(kek.ID, kdk.ID) {
+		t.Error("KEK and KDK should share the same ID")
+	}
+	if len(kek.ID) != 16 {
+		t.Errorf("Expected 16-byte ID, got %d", len(kek.ID))
+	}
+	if kek.PublicKey == nil || kdk.PrivateKey == nil {
+		t.Error("Keys should not be nil")
+	}
+}
+
+func TestSymEncryptDecrypt(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	plaintext := []byte("hello NAC world, this is a test of AES-256-GCM encryption")
+	ciphertext, err := SymEncrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("SymEncrypt failed: %v", err)
+	}
+
+	decrypted, err := SymDecrypt(key, ciphertext)
+	if err != nil {
+		t.Fatalf("SymDecrypt failed: %v", err)
+	}
+
+	if !bytes.Equal(plaintext, decrypted) {
+		t.Error("Decrypted text doesn't match original")
+	}
+}
+
+func TestSymDecryptWrongKey(t *testing.T) {
+	key1 := make([]byte, 32)
+	key2 := make([]byte, 32)
+	rand.Read(key1)
+	rand.Read(key2)
+
+	ciphertext, _ := SymEncrypt(key1, []byte("secret"))
+	_, err := SymDecrypt(key2, ciphertext)
+	if err == nil {
+		t.Error("Expected decryption to fail with wrong key")
+	}
+}
+
+func TestAsymEncryptDecrypt(t *testing.T) {
+	curve := ecdh.X25519()
+	privKey, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Key generation failed: %v", err)
+	}
+
+	plaintext := []byte("secret data for ECIES test")
+	ciphertext, err := AsymEncrypt(privKey.PublicKey(), plaintext)
+	if err != nil {
+		t.Fatalf("AsymEncrypt failed: %v", err)
+	}
+
+	decrypted, err := AsymDecrypt(privKey, ciphertext)
+	if err != nil {
+		t.Fatalf("AsymDecrypt failed: %v", err)
+	}
+
+	if !bytes.Equal(plaintext, decrypted) {
+		t.Error("Decrypted text doesn't match original")
+	}
+}
+
+func TestFullEncryptionChain(t *testing.T) {
+	// Setup: Access Manager generates KEK/KDK
+	am, err := NewAccessManager("/test/read/docs")
+	if err != nil {
+		t.Fatalf("NewAccessManager failed: %v", err)
+	}
+
+	// Consumer generates X25519 key pair
+	curve := ecdh.X25519()
+	consumerPriv, _ := curve.GenerateKey(rand.Reader)
+	consumerKeyName := "/test/consumer/KEY/abc123"
+
+	// Access Manager authorizes consumer
+	err = am.AddMember(consumerKeyName, consumerPriv.PublicKey())
+	if err != nil {
+		t.Fatalf("AddMember failed: %v", err)
+	}
+
+	// Producer encrypts content
+	encryptor := NewEncryptor("/test/data", "/test/read/docs", am.KEK())
+	plaintext := []byte("This is a secret document that only authorized consumers can read.")
+
+	encContent, encCK, err := encryptor.Encrypt("/test/data/doc1", plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	// Consumer gets encrypted KDK from Access Manager
+	encKDK, ok := am.GetEncryptedKDK(consumerKeyName)
+	if !ok {
+		t.Fatal("Consumer should be authorized")
+	}
+
+	// Consumer decrypts
+	decryptor := NewDecryptor(consumerKeyName, consumerPriv)
+	decrypted, err := decryptor.Decrypt(encContent, encCK, encKDK)
+	if err != nil {
+		t.Fatalf("Decrypt failed: %v", err)
+	}
+
+	if !bytes.Equal(plaintext, decrypted) {
+		t.Errorf("Decrypted text doesn't match.\nExpected: %s\nGot: %s", plaintext, decrypted)
+	}
+}
+
+func TestUnauthorizedConsumer(t *testing.T) {
+	am, _ := NewAccessManager("/test/read/docs")
+
+	// Unauthorized consumer
+	_, ok := am.GetEncryptedKDK("/test/eve/KEY/xyz")
+	if ok {
+		t.Error("Unauthorized consumer should not get KDK")
+	}
+
+	if am.IsAuthorized("/test/eve/KEY/xyz") {
+		t.Error("Unauthorized consumer should not be authorized")
+	}
+}
+
+func TestMultipleConsumers(t *testing.T) {
+	am, _ := NewAccessManager("/test/read/docs")
+
+	curve := ecdh.X25519()
+
+	// Alice
+	alicePriv, _ := curve.GenerateKey(rand.Reader)
+	am.AddMember("/test/alice/KEY/a1", alicePriv.PublicKey())
+
+	// Bob
+	bobPriv, _ := curve.GenerateKey(rand.Reader)
+	am.AddMember("/test/bob/KEY/b1", bobPriv.PublicKey())
+
+	// Both should be authorized
+	if !am.IsAuthorized("/test/alice/KEY/a1") {
+		t.Error("Alice should be authorized")
+	}
+	if !am.IsAuthorized("/test/bob/KEY/b1") {
+		t.Error("Bob should be authorized")
+	}
+
+	// Encrypt
+	encryptor := NewEncryptor("/test/data", "/test/read/docs", am.KEK())
+	plaintext := []byte("shared secret")
+	encContent, encCK, _ := encryptor.Encrypt("/test/data/doc1", plaintext)
+
+	// Both can decrypt
+	for _, tc := range []struct {
+		name    string
+		keyName string
+		privKey *ecdh.PrivateKey
+	}{
+		{"alice", "/test/alice/KEY/a1", alicePriv},
+		{"bob", "/test/bob/KEY/b1", bobPriv},
+	} {
+		encKDK, ok := am.GetEncryptedKDK(tc.keyName)
+		if !ok {
+			t.Fatalf("%s should be authorized", tc.name)
+		}
+
+		decryptor := NewDecryptor(tc.keyName, tc.privKey)
+		decrypted, err := decryptor.Decrypt(encContent, encCK, encKDK)
+		if err != nil {
+			t.Fatalf("%s decryption failed: %v", tc.name, err)
+		}
+		if !bytes.Equal(plaintext, decrypted) {
+			t.Errorf("%s decrypted wrong content", tc.name)
+		}
+	}
+
+	// Eve cannot decrypt
+	evePriv, _ := curve.GenerateKey(rand.Reader)
+	_, ok := am.GetEncryptedKDK("/test/eve/KEY/e1")
+	if ok {
+		t.Error("Eve should not be authorized")
+	}
+	// Even if Eve somehow got Alice's encrypted KDK, she can't decrypt it
+	aliceEncKDK, _ := am.GetEncryptedKDK("/test/alice/KEY/a1")
+	_, err := AsymDecrypt(evePriv, aliceEncKDK)
+	// This should fail because Eve's private key can't decrypt Alice's KDK
+	// (the ECIES ephemeral was for Alice's public key)
+	if err == nil {
+		t.Error("Eve should not be able to decrypt Alice's KDK")
+	}
+}
+
+func TestNaming(t *testing.T) {
+	kekName := KEKName("/alice/read/docs", []byte{0x01, 0x02})
+	if kekName != "/alice/read/docs/E-KEY/0102" {
+		t.Errorf("Unexpected KEK name: %s", kekName)
+	}
+
+	kdkName := KDKName("/alice/read/docs", []byte{0x01, 0x02})
+	if kdkName != "/alice/read/docs/D-KEY/0102" {
+		t.Errorf("Unexpected KDK name: %s", kdkName)
+	}
+
+	ckName := ContentKeyName("/alice/data", []byte{0xAB, 0xCD})
+	if ckName != "/alice/data/CK/abcd" {
+		t.Errorf("Unexpected CK name: %s", ckName)
+	}
+
+	encName := EncryptedDataName("/alice/data/doc1", "/alice/data/CK/abcd")
+	if encName != "/alice/data/doc1/FOR//alice/data/CK/abcd" {
+		t.Errorf("Unexpected encrypted data name: %s", encName)
+	}
+
+	content, key, err := ParseEncryptedDataName(encName)
+	if err != nil {
+		t.Fatalf("ParseEncryptedDataName failed: %v", err)
+	}
+	if content != "/alice/data/doc1" {
+		t.Errorf("Unexpected content name: %s", content)
+	}
+	if key != "/alice/data/CK/abcd" {
+		t.Errorf("Unexpected key name: %s", key)
+	}
+}
+
+func TestKeySerialization(t *testing.T) {
+	curve := ecdh.X25519()
+	priv, _ := curve.GenerateKey(rand.Reader)
+
+	// Serialize/deserialize public key
+	pubBytes := priv.PublicKey().Bytes()
+	pub2, err := DeserializePublicKey(pubBytes)
+	if err != nil {
+		t.Fatalf("DeserializePublicKey failed: %v", err)
+	}
+	if !bytes.Equal(priv.PublicKey().Bytes(), pub2.Bytes()) {
+		t.Error("Public key round-trip failed")
+	}
+
+	// Serialize/deserialize private key
+	privBytes := priv.Bytes()
+	priv2, err := DeserializePrivateKey(privBytes)
+	if err != nil {
+		t.Fatalf("DeserializePrivateKey failed: %v", err)
+	}
+	if !bytes.Equal(priv.Bytes(), priv2.Bytes()) {
+		t.Error("Private key round-trip failed")
+	}
+}

--- a/std/nac/naming.go
+++ b/std/nac/naming.go
@@ -6,61 +6,76 @@ import (
 	"strings"
 )
 
-// NAC utilities to construct and parse NDN names
+// NAC naming conventions (aligned with NAC spec):
 //
-// names look like:
-//   encrypted content:  <content-name>/FOR/<ck-name>
-//   encrypted CK:       <ck-name>/FOR/<kek-name>
-//   encrypted KDK:      <kdk-name>/FOR/<consumer-key-name>
+//   KEK:       <access-prefix>/NAC/<dataset>/KEK/<key-id>
+//   KDK:       <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<member-key-name>
+//   CK:        <data-prefix>/CK/<ck-id>/ENCRYPTED-BY/<access-prefix>/NAC/<dataset>/KEK/<key-id>
+//   content:   <content-name> (encrypted payload, CK name embedded in TLV)
 
-// KEKName: builds NDN name for kek => <credential-prefix>/E-KEY/<hex-key-id>
-func KEKName(credentialPrefix string, keyID []byte) string {
-	return credentialPrefix + "/E-KEY/" + hex.EncodeToString(keyID)
+// KEKName: <access-prefix>/NAC/<dataset>/KEK/<hex-key-id>
+func KEKName(accessPrefix, dataset string, keyID []byte) string {
+	return accessPrefix + "/NAC/" + dataset + "/KEK/" + hex.EncodeToString(keyID)
 }
 
-// KDKName: builds NDN name for kdk => <credential-prefix>/D-KEY/<hex-key-id>
-func KDKName(credentialPrefix string, keyID []byte) string {
-	return credentialPrefix + "/D-KEY/" + hex.EncodeToString(keyID)
+// KDKName: <access-prefix>/NAC/<dataset>/KDK/<hex-key-id>
+func KDKName(accessPrefix, dataset string, keyID []byte) string {
+	return accessPrefix + "/NAC/" + dataset + "/KDK/" + hex.EncodeToString(keyID)
 }
 
-// ContentKeyName: builds NDN name for a ck => <data-prefix>/CK/<hex-ck-id>
+// EncryptedKDKName: <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<member-key-name>
+func EncryptedKDKName(accessPrefix, dataset string, keyID []byte, memberKeyName string) string {
+	return KDKName(accessPrefix, dataset, keyID) + "/ENCRYPTED-BY/" + strings.TrimPrefix(memberKeyName, "/")
+}
+
+// ContentKeyName: <data-prefix>/CK/<hex-ck-id>
 func ContentKeyName(dataPrefix string, ckID []byte) string {
 	return dataPrefix + "/CK/" + hex.EncodeToString(ckID)
 }
 
-// EncryptedDataName: builds the /FOR/ formated name to link encrypted data to the key that encrypted it
-func EncryptedDataName(contentName, encryptingKeyName string) string {
-	return contentName + "/FOR/" + encryptingKeyName
+// CKEncryptedName: <data-prefix>/CK/<ck-id>/ENCRYPTED-BY/<kek-name>
+func CKEncryptedName(dataPrefix string, ckID []byte, kekName string) string {
+	return ContentKeyName(dataPrefix, ckID) + "/ENCRYPTED-BY/" + strings.TrimPrefix(kekName, "/")
 }
 
-// ConsumerKeyName: builds NDN name for consumer's identity key => <consumer-id>/KEY/<hex-key-id>
+// ConsumerKeyName: <consumer-id>/KEY/<hex-key-id>
 func ConsumerKeyName(consumerIdentity string, keyID []byte) string {
 	return consumerIdentity + "/KEY/" + hex.EncodeToString(keyID)
 }
 
-// ParseEncryptedDataName: gets content name + encrypting key name
-func ParseEncryptedDataName(name string) (contentName, keyName string, err error) {
-	idx := strings.Index(name, "/FOR/")
+// ParseEncryptedByName: splits on /ENCRYPTED-BY/
+func ParseEncryptedByName(name string) (baseName, keyName string, err error) {
+	idx := strings.Index(name, "/ENCRYPTED-BY/")
 	if idx == -1 {
-		return "", "", fmt.Errorf("no /FOR/ in name: %s", name)
+		return "", "", fmt.Errorf("no /ENCRYPTED-BY/ in name: %s", name)
 	}
-	return name[:idx], name[idx+len("/FOR/"):], nil
+	return name[:idx], name[idx+len("/ENCRYPTED-BY/"):], nil
 }
 
-// ParseKEKName: gets credential prefix + hex key id from a KEK name
-func ParseKEKName(name string) (credentialPrefix, keyIDHex string, err error) {
-	idx := strings.Index(name, "/E-KEY/")
-	if idx == -1 {
-		return "", "", fmt.Errorf("no /E-KEY/ in name: %s", name)
+// ParseKEKName: extracts access prefix, dataset, and key ID from a KEK name
+func ParseKEKName(name string) (accessPrefix, dataset, keyIDHex string, err error) {
+	nacIdx := strings.Index(name, "/NAC/")
+	if nacIdx == -1 {
+		return "", "", "", fmt.Errorf("no /NAC/ in name: %s", name)
 	}
-	return name[:idx], name[idx+len("/E-KEY/"):], nil
+	rest := name[nacIdx+len("/NAC/"):]
+	kekIdx := strings.Index(rest, "/KEK/")
+	if kekIdx == -1 {
+		return "", "", "", fmt.Errorf("no /KEK/ in name: %s", name)
+	}
+	return name[:nacIdx], rest[:kekIdx], rest[kekIdx+len("/KEK/"):], nil
 }
 
-// ParseKDKName: gets credential prefix + hex key id from a KDK name
-func ParseKDKName(name string) (credentialPrefix, keyIDHex string, err error) {
-	idx := strings.Index(name, "/D-KEY/")
-	if idx == -1 {
-		return "", "", fmt.Errorf("no /D-KEY/ in name: %s", name)
+// ParseKDKName: extracts access prefix, dataset, and key ID from a KDK name
+func ParseKDKName(name string) (accessPrefix, dataset, keyIDHex string, err error) {
+	nacIdx := strings.Index(name, "/NAC/")
+	if nacIdx == -1 {
+		return "", "", "", fmt.Errorf("no /NAC/ in name: %s", name)
 	}
-	return name[:idx], name[idx+len("/D-KEY/"):], nil
+	rest := name[nacIdx+len("/NAC/"):]
+	kdkIdx := strings.Index(rest, "/KDK/")
+	if kdkIdx == -1 {
+		return "", "", "", fmt.Errorf("no /KDK/ in name: %s", name)
+	}
+	return name[:nacIdx], rest[:kdkIdx], rest[kdkIdx+len("/KDK/"):], nil
 }

--- a/std/nac/naming.go
+++ b/std/nac/naming.go
@@ -1,0 +1,66 @@
+package nac
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// NAC utilities to construct and parse NDN names
+//
+// names look like:
+//   encrypted content:  <content-name>/FOR/<ck-name>
+//   encrypted CK:       <ck-name>/FOR/<kek-name>
+//   encrypted KDK:      <kdk-name>/FOR/<consumer-key-name>
+
+// KEKName: builds NDN name for kek => <credential-prefix>/E-KEY/<hex-key-id>
+func KEKName(credentialPrefix string, keyID []byte) string {
+	return credentialPrefix + "/E-KEY/" + hex.EncodeToString(keyID)
+}
+
+// KDKName: builds NDN name for kdk => <credential-prefix>/D-KEY/<hex-key-id>
+func KDKName(credentialPrefix string, keyID []byte) string {
+	return credentialPrefix + "/D-KEY/" + hex.EncodeToString(keyID)
+}
+
+// ContentKeyName: builds NDN name for a ck => <data-prefix>/CK/<hex-ck-id>
+func ContentKeyName(dataPrefix string, ckID []byte) string {
+	return dataPrefix + "/CK/" + hex.EncodeToString(ckID)
+}
+
+// EncryptedDataName: builds the /FOR/ formated name to link encrypted data to the key that encrypted it
+func EncryptedDataName(contentName, encryptingKeyName string) string {
+	return contentName + "/FOR/" + encryptingKeyName
+}
+
+// ConsumerKeyName: builds NDN name for consumer's identity key => <consumer-id>/KEY/<hex-key-id>
+func ConsumerKeyName(consumerIdentity string, keyID []byte) string {
+	return consumerIdentity + "/KEY/" + hex.EncodeToString(keyID)
+}
+
+// ParseEncryptedDataName: gets content name + encrypting key name
+func ParseEncryptedDataName(name string) (contentName, keyName string, err error) {
+	idx := strings.Index(name, "/FOR/")
+	if idx == -1 {
+		return "", "", fmt.Errorf("no /FOR/ in name: %s", name)
+	}
+	return name[:idx], name[idx+len("/FOR/"):], nil
+}
+
+// ParseKEKName: gets credential prefix + hex key id from a KEK name
+func ParseKEKName(name string) (credentialPrefix, keyIDHex string, err error) {
+	idx := strings.Index(name, "/E-KEY/")
+	if idx == -1 {
+		return "", "", fmt.Errorf("no /E-KEY/ in name: %s", name)
+	}
+	return name[:idx], name[idx+len("/E-KEY/"):], nil
+}
+
+// ParseKDKName: gets credential prefix + hex key id from a KDK name
+func ParseKDKName(name string) (credentialPrefix, keyIDHex string, err error) {
+	idx := strings.Index(name, "/D-KEY/")
+	if idx == -1 {
+		return "", "", fmt.Errorf("no /D-KEY/ in name: %s", name)
+	}
+	return name[:idx], name[idx+len("/D-KEY/"):], nil
+}

--- a/std/nac/server.go
+++ b/std/nac/server.go
@@ -15,9 +15,9 @@ import (
 // KeyServer serves NAC keys over NDN.
 //
 // It exposes:
-//   - KEK publicly at <credential-prefix>/E-KEY/<key-id> (any producer can fetch)
-//   - Encrypted KDKs at <kdk-name>/FOR/<consumer-key-name> (only authorized consumers)
-//   - Enrollment at <credential-prefix>/ENROLL (signed Interest with X25519 pubkey)
+//   - KEK publicly at <access-prefix>/NAC/<dataset>/KEK/<key-id>
+//   - Encrypted KDKs at <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<member>
+//   - Enrollment at <access-prefix>/NAC/<dataset>/ENROLL
 //
 // The key server wraps an AccessManager and attaches NDN Interest handlers.
 type KeyServer struct {
@@ -25,31 +25,31 @@ type KeyServer struct {
 	signer ndn.Signer
 	am     *AccessManager
 
-	credPrefix enc.Name
+	nacPrefix enc.Name // <access-prefix>/NAC/<dataset>
 
-	// issuedCerts maps key name prefix (e.g., /demo/emmettlsc.com/KEY/...)
-	// to certificate Data. Used to verify enrollment request signatures.
-	// Populated by the CA server when it issues certificates.
+	// issuedCerts maps key name prefix to certificate Data.
+	// Used to verify enrollment request signatures.
 	issuedCerts map[string]ndn.Data
 }
 
-// NewKeyServer creates a NAC key server.
-func NewKeyServer(engine ndn.Engine, signer ndn.Signer, credentialPrefix string) (*KeyServer, error) {
-	am, err := NewAccessManager(credentialPrefix)
+// NewKeyServer creates a NAC key server for <accessPrefix>/NAC/<dataset>.
+func NewKeyServer(engine ndn.Engine, signer ndn.Signer, accessPrefix, dataset string) (*KeyServer, error) {
+	am, err := NewAccessManager(accessPrefix, dataset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create access manager: %w", err)
 	}
 
-	prefix, err := enc.NameFromStr(credentialPrefix)
+	nacPrefixStr := accessPrefix + "/NAC/" + dataset
+	prefix, err := enc.NameFromStr(nacPrefixStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid credential prefix: %w", err)
+		return nil, fmt.Errorf("invalid NAC prefix: %w", err)
 	}
 
 	return &KeyServer{
 		engine:      engine,
 		signer:      signer,
 		am:          am,
-		credPrefix:  prefix,
+		nacPrefix:   prefix,
 		issuedCerts: make(map[string]ndn.Data),
 	}, nil
 }
@@ -75,43 +75,38 @@ func (ks *KeyServer) RegisterCACert(cert ndn.Data) {
 
 // Start registers NDN routes and attaches Interest handlers.
 func (ks *KeyServer) Start() error {
-	// Register the credential prefix route
-	if err := ks.engine.RegisterRoute(ks.credPrefix); err != nil {
+	if err := ks.engine.RegisterRoute(ks.nacPrefix); err != nil {
 		return fmt.Errorf("failed to register route: %w", err)
 	}
 
-	// Attach KEK handler: <credential-prefix>/E-KEY
-	kekPrefix := ks.credPrefix.Append(enc.NewGenericComponent("E-KEY"))
+	kekPrefix := ks.nacPrefix.Append(enc.NewGenericComponent("KEK"))
 	if err := ks.engine.AttachHandler(kekPrefix, ks.onKEKInterest); err != nil {
 		return fmt.Errorf("failed to attach KEK handler: %w", err)
 	}
 
-	// Attach KDK handler: <credential-prefix>/D-KEY
-	kdkPrefix := ks.credPrefix.Append(enc.NewGenericComponent("D-KEY"))
+	kdkPrefix := ks.nacPrefix.Append(enc.NewGenericComponent("KDK"))
 	if err := ks.engine.AttachHandler(kdkPrefix, ks.onKDKInterest); err != nil {
 		return fmt.Errorf("failed to attach KDK handler: %w", err)
 	}
 
-	// Attach ENROLL handler: <credential-prefix>/ENROLL
-	enrollPrefix := ks.credPrefix.Append(enc.NewGenericComponent("ENROLL"))
+	enrollPrefix := ks.nacPrefix.Append(enc.NewGenericComponent("ENROLL"))
 	if err := ks.engine.AttachHandler(enrollPrefix, ks.onEnrollInterest); err != nil {
 		return fmt.Errorf("failed to attach ENROLL handler: %w", err)
 	}
 
-	fmt.Printf("NAC KeyServer started at %s\n", ks.credPrefix)
+	fmt.Printf("NAC KeyServer started at %s\n", ks.nacPrefix)
 	return nil
 }
 
-// Stop detaches Interest handlers.
 func (ks *KeyServer) Stop() error {
-	ks.engine.DetachHandler(ks.credPrefix.Append(enc.NewGenericComponent("E-KEY")))
-	ks.engine.DetachHandler(ks.credPrefix.Append(enc.NewGenericComponent("D-KEY")))
-	ks.engine.DetachHandler(ks.credPrefix.Append(enc.NewGenericComponent("ENROLL")))
+	ks.engine.DetachHandler(ks.nacPrefix.Append(enc.NewGenericComponent("KEK")))
+	ks.engine.DetachHandler(ks.nacPrefix.Append(enc.NewGenericComponent("KDK")))
+	ks.engine.DetachHandler(ks.nacPrefix.Append(enc.NewGenericComponent("ENROLL")))
 	return nil
 }
 
 // onKEKInterest handles Interest for the public KEK.
-// Interest name: <credential-prefix>/E-KEY/<key-id>
+// Interest name: <access-prefix>/NAC/<dataset>/KEK/<key-id>
 func (ks *KeyServer) onKEKInterest(args ndn.InterestHandlerArgs) {
 	kek := ks.am.KEK()
 	pubKeyBytes := kek.PublicKey.Bytes()
@@ -137,7 +132,7 @@ func (ks *KeyServer) onKEKInterest(args ndn.InterestHandlerArgs) {
 
 // onEnrollInterest handles NAC enrollment requests.
 //
-// The client sends an Interest to <credential-prefix>/ENROLL with AppParam
+// The client sends an Interest to <access-prefix>/NAC/<dataset>/ENROLL with AppParam
 // containing: [32 bytes X25519 public key] [certificate wire bytes]
 //
 // The server:
@@ -263,13 +258,13 @@ func (ks *KeyServer) replyEnrollError(args ndn.InterestHandlerArgs, msg string) 
 }
 
 // onKDKInterest handles Interest for encrypted KDKs.
-// Interest name: <credential-prefix>/D-KEY/<key-id>/FOR/<consumer-key-name>
+// Interest name: <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<consumer-key-name>
 func (ks *KeyServer) onKDKInterest(args ndn.InterestHandlerArgs) {
 	name := args.Interest.Name()
 
-	// Parse the consumer key name from the /FOR/ component
+	// Parse the consumer key name from the /ENCRYPTED-BY/ component
 	nameStr := name.String()
-	_, consumerKeyName, err := ParseEncryptedDataName(nameStr)
+	_, consumerKeyName, err := ParseEncryptedByName(nameStr)
 	if err != nil {
 		fmt.Printf("NAC KeyServer: invalid KDK Interest name: %s\n", nameStr)
 		return

--- a/std/nac/server.go
+++ b/std/nac/server.go
@@ -1,11 +1,14 @@
 package nac
 
 import (
+	"encoding/hex"
 	"fmt"
 	"time"
 
 	enc "github.com/named-data/ndnd/std/encoding"
 	"github.com/named-data/ndnd/std/ndn"
+	spec "github.com/named-data/ndnd/std/ndn/spec_2022"
+	sig "github.com/named-data/ndnd/std/security/signer"
 	"github.com/named-data/ndnd/std/types/optional"
 )
 
@@ -14,6 +17,7 @@ import (
 // It exposes:
 //   - KEK publicly at <credential-prefix>/E-KEY/<key-id> (any producer can fetch)
 //   - Encrypted KDKs at <kdk-name>/FOR/<consumer-key-name> (only authorized consumers)
+//   - Enrollment at <credential-prefix>/ENROLL (signed Interest with X25519 pubkey)
 //
 // The key server wraps an AccessManager and attaches NDN Interest handlers.
 type KeyServer struct {
@@ -22,6 +26,11 @@ type KeyServer struct {
 	am     *AccessManager
 
 	credPrefix enc.Name
+
+	// issuedCerts maps key name prefix (e.g., /demo/emmettlsc.com/KEY/...)
+	// to certificate Data. Used to verify enrollment request signatures.
+	// Populated by the CA server when it issues certificates.
+	issuedCerts map[string]ndn.Data
 }
 
 // NewKeyServer creates a NAC key server.
@@ -37,16 +46,31 @@ func NewKeyServer(engine ndn.Engine, signer ndn.Signer, credentialPrefix string)
 	}
 
 	return &KeyServer{
-		engine:     engine,
-		signer:     signer,
-		am:         am,
-		credPrefix: prefix,
+		engine:      engine,
+		signer:      signer,
+		am:          am,
+		credPrefix:  prefix,
+		issuedCerts: make(map[string]ndn.Data),
 	}, nil
 }
 
 // AccessManager returns the underlying access manager.
 func (ks *KeyServer) AccessManager() *AccessManager {
 	return ks.am
+}
+
+// RegisterCACert registers a CA certificate as a trust anchor for verifying
+// enrollment requests. Client certificates must be signed by one of these CAs.
+// The cert is indexed by its key name (cert name minus issuer and version).
+func (ks *KeyServer) RegisterCACert(cert ndn.Data) {
+	// Store by the key name (cert name minus issuer + version)
+	// e.g., /demo/KEY/<id> from /demo/KEY/<id>/NA/v=...
+	keyName := cert.Name()
+	if len(keyName) >= 2 {
+		keyName = keyName[:len(keyName)-2]
+	}
+	ks.issuedCerts[keyName.String()] = cert
+	fmt.Printf("NAC KeyServer: registered CA cert: %s\n", keyName)
 }
 
 // Start registers NDN routes and attaches Interest handlers.
@@ -68,6 +92,12 @@ func (ks *KeyServer) Start() error {
 		return fmt.Errorf("failed to attach KDK handler: %w", err)
 	}
 
+	// Attach ENROLL handler: <credential-prefix>/ENROLL
+	enrollPrefix := ks.credPrefix.Append(enc.NewGenericComponent("ENROLL"))
+	if err := ks.engine.AttachHandler(enrollPrefix, ks.onEnrollInterest); err != nil {
+		return fmt.Errorf("failed to attach ENROLL handler: %w", err)
+	}
+
 	fmt.Printf("NAC KeyServer started at %s\n", ks.credPrefix)
 	return nil
 }
@@ -76,6 +106,7 @@ func (ks *KeyServer) Start() error {
 func (ks *KeyServer) Stop() error {
 	ks.engine.DetachHandler(ks.credPrefix.Append(enc.NewGenericComponent("E-KEY")))
 	ks.engine.DetachHandler(ks.credPrefix.Append(enc.NewGenericComponent("D-KEY")))
+	ks.engine.DetachHandler(ks.credPrefix.Append(enc.NewGenericComponent("ENROLL")))
 	return nil
 }
 
@@ -101,6 +132,133 @@ func (ks *KeyServer) onKEKInterest(args ndn.InterestHandlerArgs) {
 		return
 	}
 
+	args.Reply(data.Wire)
+}
+
+// onEnrollInterest handles NAC enrollment requests.
+//
+// The client sends an Interest to <credential-prefix>/ENROLL with AppParam
+// containing: [32 bytes X25519 public key] [certificate wire bytes]
+//
+// The server:
+//  1. Splits AppParam into X25519 key (first 32 bytes) and certificate (rest)
+//  2. Parses the certificate and verifies it was signed by the CA
+//  3. Extracts the consumer identity from the certificate name
+//  4. Registers the X25519 key as an authorized NAC member
+//
+// This ties NDNCERT identity to NAC access: only clients with CA-issued
+// certificates can enroll for encrypted content access.
+func (ks *KeyServer) onEnrollInterest(args ndn.InterestHandlerArgs) {
+	fmt.Printf("NAC ENROLL: handler invoked for %s\n", args.Interest.Name())
+	appParam := args.Interest.AppParam()
+	if appParam == nil {
+		fmt.Println("NAC ENROLL: missing AppParam")
+		ks.replyEnrollError(args, "missing AppParam")
+		return
+	}
+
+	payload := appParam.Join()
+
+	// AppParam format: [32-byte X25519 pubkey][certificate wire]
+	if len(payload) < 33 {
+		fmt.Println("NAC ENROLL: AppParam too short")
+		ks.replyEnrollError(args, "AppParam too short")
+		return
+	}
+
+	x25519PubBytes := payload[:32]
+	certWireBytes := payload[32:]
+
+	// Parse the X25519 public key
+	consumerPubKey, err := DeserializePublicKey(x25519PubBytes)
+	if err != nil {
+		fmt.Printf("NAC ENROLL: invalid X25519 key: %v\n", err)
+		ks.replyEnrollError(args, "invalid X25519 public key")
+		return
+	}
+
+	// Parse the client's certificate
+	clientCert, sigCovered, err := spec.Spec{}.ReadData(enc.NewBufferView(certWireBytes))
+	if err != nil {
+		fmt.Printf("NAC ENROLL: failed to parse certificate: %v\n", err)
+		ks.replyEnrollError(args, "invalid certificate")
+		return
+	}
+
+	fmt.Printf("NAC ENROLL: request from %s\n", clientCert.Name())
+
+	// Verify the certificate was signed by our CA
+	// Look up the CA cert that matches the signer key name
+	signerKeyName := clientCert.Signature().KeyName()
+	caCert, ok := ks.issuedCerts[signerKeyName.String()]
+	if !ok {
+		fmt.Printf("NAC ENROLL: certificate signer %s not recognized\n", signerKeyName)
+		ks.replyEnrollError(args, "certificate not signed by recognized CA")
+		return
+	}
+
+	valid, err := sig.ValidateData(clientCert, sigCovered, caCert)
+	if err != nil || !valid {
+		fmt.Printf("NAC ENROLL: certificate verification failed: valid=%v err=%v\n", valid, err)
+		ks.replyEnrollError(args, "certificate verification failed")
+		return
+	}
+
+	// Derive consumer key name from the certificate
+	// Certificate name: /demo/emmettlsc.com/KEY/<id>/NDNCERT/v=...
+	// Key name (strip issuer + version): /demo/emmettlsc.com/KEY/<id>
+	consumerKeyName := clientCert.Name()
+	if len(consumerKeyName) >= 2 {
+		consumerKeyName = consumerKeyName[:len(consumerKeyName)-2]
+	}
+
+	// Add as authorized member
+	if err := ks.am.AddMember(consumerKeyName.String(), consumerPubKey); err != nil {
+		fmt.Printf("NAC ENROLL: failed to add member: %v\n", err)
+		ks.replyEnrollError(args, "enrollment failed")
+		return
+	}
+
+	fmt.Printf("NAC ENROLL: SUCCESS - enrolled %s (X25519 pub: %s)\n",
+		consumerKeyName, hex.EncodeToString(x25519PubBytes))
+
+	// Reply with success + KEK public key so client knows the encryption key
+	kek := ks.am.KEK()
+	kekPubBytes := kek.PublicKey.Bytes()
+	kekIDBytes := kek.ID
+	// Response: "OK:" + KEK pub (32 bytes) + KEK ID (16 bytes)
+	response := append([]byte("OK:"), kekPubBytes...)
+	response = append(response, kekIDBytes...)
+
+	cfg := &ndn.DataConfig{
+		Freshness: optional.Some(4 * time.Second),
+	}
+	data, err := ks.engine.Spec().MakeData(
+		args.Interest.Name(),
+		cfg,
+		enc.Wire{response},
+		ks.signer,
+	)
+	if err != nil {
+		fmt.Printf("NAC ENROLL: failed to create response: %v\n", err)
+		return
+	}
+	args.Reply(data.Wire)
+}
+
+func (ks *KeyServer) replyEnrollError(args ndn.InterestHandlerArgs, msg string) {
+	cfg := &ndn.DataConfig{
+		Freshness: optional.Some(4 * time.Second),
+	}
+	data, err := ks.engine.Spec().MakeData(
+		args.Interest.Name(),
+		cfg,
+		enc.Wire{[]byte("ERR:" + msg)},
+		ks.signer,
+	)
+	if err != nil {
+		return
+	}
 	args.Reply(data.Wire)
 }
 

--- a/std/nac/server.go
+++ b/std/nac/server.go
@@ -1,6 +1,7 @@
 package nac
 
 import (
+	"crypto/ecdh"
 	"encoding/hex"
 	"fmt"
 	"time"
@@ -8,31 +9,30 @@ import (
 	enc "github.com/named-data/ndnd/std/encoding"
 	"github.com/named-data/ndnd/std/ndn"
 	spec "github.com/named-data/ndnd/std/ndn/spec_2022"
+	"github.com/named-data/ndnd/std/object/storage"
 	sig "github.com/named-data/ndnd/std/security/signer"
 	"github.com/named-data/ndnd/std/types/optional"
 )
 
-// KeyServer serves NAC keys over NDN.
+// key server for NAC - pre-produces signed KEK/KDK data packets and serves
+// them from an in-memory store so routers can cache them
 //
-// It exposes:
-//   - KEK publicly at <access-prefix>/NAC/<dataset>/KEK/<key-id>
-//   - Encrypted KDKs at <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<member>
-//   - Enrollment at <access-prefix>/NAC/<dataset>/ENROLL
-//
-// The key server wraps an AccessManager and attaches NDN Interest handlers.
+//   KEK at <access-prefix>/NAC/<dataset>/KEK/<key-id>
+//   KDK at <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<member>
+//   ENROLL at <access-prefix>/NAC/<dataset>/ENROLL
 type KeyServer struct {
 	engine ndn.Engine
 	signer ndn.Signer
 	am     *AccessManager
+	store  *storage.MemoryStore
 
 	nacPrefix enc.Name // <access-prefix>/NAC/<dataset>
 
-	// issuedCerts maps key name prefix to certificate Data.
-	// Used to verify enrollment request signatures.
+	// ca certs for verifying enrollment signatures, keyed by key name
 	issuedCerts map[string]ndn.Data
 }
 
-// NewKeyServer creates a NAC key server for <accessPrefix>/NAC/<dataset>.
+// creates a NAC key server for <accessPrefix>/NAC/<dataset>
 func NewKeyServer(engine ndn.Engine, signer ndn.Signer, accessPrefix, dataset string) (*KeyServer, error) {
 	am, err := NewAccessManager(accessPrefix, dataset)
 	if err != nil {
@@ -49,22 +49,22 @@ func NewKeyServer(engine ndn.Engine, signer ndn.Signer, accessPrefix, dataset st
 		engine:      engine,
 		signer:      signer,
 		am:          am,
+		store:       storage.NewMemoryStore(),
 		nacPrefix:   prefix,
 		issuedCerts: make(map[string]ndn.Data),
 	}, nil
 }
 
-// AccessManager returns the underlying access manager.
+// returns the underlying access manager
 func (ks *KeyServer) AccessManager() *AccessManager {
 	return ks.am
 }
 
-// RegisterCACert registers a CA certificate as a trust anchor for verifying
-// enrollment requests. Client certificates must be signed by one of these CAs.
-// The cert is indexed by its key name (cert name minus issuer and version).
+// register a CA cert as trust anchor for enrollment verification
+// indexed by key name (cert name minus issuer and version)
 func (ks *KeyServer) RegisterCACert(cert ndn.Data) {
-	// Store by the key name (cert name minus issuer + version)
-	// e.g., /demo/KEY/<id> from /demo/KEY/<id>/NA/v=...
+	// store by key name (cert name minus issuer + version)
+	// eg /demo/KEY/<id> from /demo/KEY/<id>/NA/v=...
 	keyName := cert.Name()
 	if len(keyName) >= 2 {
 		keyName = keyName[:len(keyName)-2]
@@ -73,22 +73,23 @@ func (ks *KeyServer) RegisterCACert(cert ndn.Data) {
 	fmt.Printf("NAC KeyServer: registered CA cert: %s\n", keyName)
 }
 
-// Start registers NDN routes and attaches Interest handlers.
+// pre-produce KEK, register routes, attach handlers
 func (ks *KeyServer) Start() error {
+	// produce KEK once at startup
+	if err := ks.produceKEK(); err != nil {
+		return fmt.Errorf("failed to produce KEK: %w", err)
+	}
+
 	if err := ks.engine.RegisterRoute(ks.nacPrefix); err != nil {
 		return fmt.Errorf("failed to register route: %w", err)
 	}
 
-	kekPrefix := ks.nacPrefix.Append(enc.NewGenericComponent("KEK"))
-	if err := ks.engine.AttachHandler(kekPrefix, ks.onKEKInterest); err != nil {
-		return fmt.Errorf("failed to attach KEK handler: %w", err)
+	// one handler serves everything from the store
+	if err := ks.engine.AttachHandler(ks.nacPrefix, ks.onFetch); err != nil {
+		return fmt.Errorf("failed to attach fetch handler: %w", err)
 	}
 
-	kdkPrefix := ks.nacPrefix.Append(enc.NewGenericComponent("KDK"))
-	if err := ks.engine.AttachHandler(kdkPrefix, ks.onKDKInterest); err != nil {
-		return fmt.Errorf("failed to attach KDK handler: %w", err)
-	}
-
+	// enroll is dynamic - produces new KDK packets on demand
 	enrollPrefix := ks.nacPrefix.Append(enc.NewGenericComponent("ENROLL"))
 	if err := ks.engine.AttachHandler(enrollPrefix, ks.onEnrollInterest); err != nil {
 		return fmt.Errorf("failed to attach ENROLL handler: %w", err)
@@ -99,50 +100,75 @@ func (ks *KeyServer) Start() error {
 }
 
 func (ks *KeyServer) Stop() error {
-	ks.engine.DetachHandler(ks.nacPrefix.Append(enc.NewGenericComponent("KEK")))
-	ks.engine.DetachHandler(ks.nacPrefix.Append(enc.NewGenericComponent("KDK")))
+	ks.engine.DetachHandler(ks.nacPrefix)
 	ks.engine.DetachHandler(ks.nacPrefix.Append(enc.NewGenericComponent("ENROLL")))
 	return nil
 }
 
-// onKEKInterest handles Interest for the public KEK.
-// Interest name: <access-prefix>/NAC/<dataset>/KEK/<key-id>
-func (ks *KeyServer) onKEKInterest(args ndn.InterestHandlerArgs) {
+// sign and store the KEK data packet
+func (ks *KeyServer) produceKEK() error {
 	kek := ks.am.KEK()
-	pubKeyBytes := kek.PublicKey.Bytes()
+	kekNameStr := KEKName(ks.am.AccessPrefix(), ks.am.Dataset(), kek.ID)
+	kekName, err := enc.NameFromStr(kekNameStr)
+	if err != nil {
+		return fmt.Errorf("invalid KEK name: %w", err)
+	}
 
-	cfg := &ndn.DataConfig{
+	data, err := ks.engine.Spec().MakeData(kekName, &ndn.DataConfig{
 		ContentType: optional.Some(ndn.ContentTypeKey),
 		Freshness:   optional.Some(time.Hour),
-	}
-
-	data, err := ks.engine.Spec().MakeData(
-		args.Interest.Name(),
-		cfg,
-		enc.Wire{pubKeyBytes},
-		ks.signer,
-	)
+	}, enc.Wire{kek.PublicKey.Bytes()}, ks.signer)
 	if err != nil {
-		fmt.Printf("NAC KeyServer: failed to create KEK response: %v\n", err)
-		return
+		return fmt.Errorf("failed to sign KEK: %w", err)
 	}
 
-	args.Reply(data.Wire)
+	return ks.store.Put(kekName, data.Wire.Join())
 }
 
-// onEnrollInterest handles NAC enrollment requests.
-//
-// The client sends an Interest to <access-prefix>/NAC/<dataset>/ENROLL with AppParam
-// containing: [32 bytes X25519 public key] [certificate wire bytes]
-//
-// The server:
-//  1. Splits AppParam into X25519 key (first 32 bytes) and certificate (rest)
-//  2. Parses the certificate and verifies it was signed by the CA
-//  3. Extracts the consumer identity from the certificate name
-//  4. Registers the X25519 key as an authorized NAC member
-//
-// This ties NDNCERT identity to NAC access: only clients with CA-issued
-// certificates can enroll for encrypted content access.
+func (ks *KeyServer) produceKDK(consumerKeyName string) error {
+	encKDK, ok := ks.am.GetEncryptedKDK(consumerKeyName)
+	if !ok {
+		return fmt.Errorf("consumer not authorized: %s", consumerKeyName)
+	}
+
+	kdkNameStr := EncryptedKDKName(
+		ks.am.AccessPrefix(), ks.am.Dataset(), ks.am.KDKID(), consumerKeyName,
+	)
+	kdkName, err := enc.NameFromStr(kdkNameStr)
+	if err != nil {
+		return fmt.Errorf("invalid KDK name: %w", err)
+	}
+
+	data, err := ks.engine.Spec().MakeData(kdkName, &ndn.DataConfig{
+		ContentType: optional.Some(ndn.ContentTypeKey),
+		Freshness:   optional.Some(time.Hour),
+	}, enc.Wire{encKDK}, ks.signer)
+	if err != nil {
+		return fmt.Errorf("failed to sign KDK: %w", err)
+	}
+
+	return ks.store.Put(kdkName, data.Wire.Join())
+}
+
+// AddMember authorizes a consumer and produces their signed KDK Data packet.
+func (ks *KeyServer) AddMember(consumerKeyName string, consumerPubKey *ecdh.PublicKey) error {
+	if err := ks.am.AddMember(consumerKeyName, consumerPubKey); err != nil {
+		return err
+	}
+	return ks.produceKDK(normalizeKeyName(consumerKeyName))
+}
+
+// serve pre-produced packets from the store
+func (ks *KeyServer) onFetch(args ndn.InterestHandlerArgs) {
+	data, err := ks.store.Get(args.Interest.Name(), args.Interest.CanBePrefix())
+	if err != nil || data == nil {
+		return
+	}
+	args.Reply(enc.Wire{data})
+}
+
+// handle enrollment - client sends [32B x25519 pubkey][cert wire] to ENROLL
+// server verifies cert against CA, authorizes consumer, produces KDK packet
 func (ks *KeyServer) onEnrollInterest(args ndn.InterestHandlerArgs) {
 	fmt.Printf("NAC ENROLL: handler invoked for %s\n", args.Interest.Name())
 	appParam := args.Interest.AppParam()
@@ -154,7 +180,7 @@ func (ks *KeyServer) onEnrollInterest(args ndn.InterestHandlerArgs) {
 
 	payload := appParam.Join()
 
-	// AppParam format: [32-byte X25519 pubkey][certificate wire]
+	// [32-byte x25519 pubkey][certificate wire]
 	if len(payload) < 33 {
 		fmt.Println("NAC ENROLL: AppParam too short")
 		ks.replyEnrollError(args, "AppParam too short")
@@ -164,7 +190,7 @@ func (ks *KeyServer) onEnrollInterest(args ndn.InterestHandlerArgs) {
 	x25519PubBytes := payload[:32]
 	certWireBytes := payload[32:]
 
-	// Parse the X25519 public key
+	// parse x25519 pubkey
 	consumerPubKey, err := DeserializePublicKey(x25519PubBytes)
 	if err != nil {
 		fmt.Printf("NAC ENROLL: invalid X25519 key: %v\n", err)
@@ -172,7 +198,7 @@ func (ks *KeyServer) onEnrollInterest(args ndn.InterestHandlerArgs) {
 		return
 	}
 
-	// Parse the client's certificate
+	// parse client cert
 	clientCert, sigCovered, err := spec.Spec{}.ReadData(enc.NewBufferView(certWireBytes))
 	if err != nil {
 		fmt.Printf("NAC ENROLL: failed to parse certificate: %v\n", err)
@@ -182,8 +208,7 @@ func (ks *KeyServer) onEnrollInterest(args ndn.InterestHandlerArgs) {
 
 	fmt.Printf("NAC ENROLL: request from %s\n", clientCert.Name())
 
-	// Verify the certificate was signed by our CA
-	// Look up the CA cert that matches the signer key name
+	// verify cert was signed by a registered CA
 	signerKeyName := clientCert.Signature().KeyName()
 	caCert, ok := ks.issuedCerts[signerKeyName.String()]
 	if !ok {
@@ -199,16 +224,14 @@ func (ks *KeyServer) onEnrollInterest(args ndn.InterestHandlerArgs) {
 		return
 	}
 
-	// Derive consumer key name from the certificate
-	// Certificate name: /demo/emmettlsc.com/KEY/<id>/NDNCERT/v=...
-	// Key name (strip issuer + version): /demo/emmettlsc.com/KEY/<id>
+	// derive consumer key name from cert (strip issuer + version suffix)
 	consumerKeyName := clientCert.Name()
 	if len(consumerKeyName) >= 2 {
 		consumerKeyName = consumerKeyName[:len(consumerKeyName)-2]
 	}
 
-	// Add as authorized member
-	if err := ks.am.AddMember(consumerKeyName.String(), consumerPubKey); err != nil {
+	// authorize and produce KDK data packet
+	if err := ks.AddMember(consumerKeyName.String(), consumerPubKey); err != nil {
 		fmt.Printf("NAC ENROLL: failed to add member: %v\n", err)
 		ks.replyEnrollError(args, "enrollment failed")
 		return
@@ -217,11 +240,11 @@ func (ks *KeyServer) onEnrollInterest(args ndn.InterestHandlerArgs) {
 	fmt.Printf("NAC ENROLL: SUCCESS - enrolled %s (X25519 pub: %s)\n",
 		consumerKeyName, hex.EncodeToString(x25519PubBytes))
 
-	// Reply with success + KEK public key so client knows the encryption key
+	// reply with KEK pub + ID so client can encrypt
 	kek := ks.am.KEK()
 	kekPubBytes := kek.PublicKey.Bytes()
 	kekIDBytes := kek.ID
-	// Response: "OK:" + KEK pub (32 bytes) + KEK ID (16 bytes)
+	// "OK:" + KEK pub (32 bytes) + KEK ID (16 bytes)
 	response := append([]byte("OK:"), kekPubBytes...)
 	response = append(response, kekIDBytes...)
 
@@ -257,40 +280,3 @@ func (ks *KeyServer) replyEnrollError(args ndn.InterestHandlerArgs, msg string) 
 	args.Reply(data.Wire)
 }
 
-// onKDKInterest handles Interest for encrypted KDKs.
-// Interest name: <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<consumer-key-name>
-func (ks *KeyServer) onKDKInterest(args ndn.InterestHandlerArgs) {
-	name := args.Interest.Name()
-
-	// Parse the consumer key name from the /ENCRYPTED-BY/ component
-	nameStr := name.String()
-	_, consumerKeyName, err := ParseEncryptedByName(nameStr)
-	if err != nil {
-		fmt.Printf("NAC KeyServer: invalid KDK Interest name: %s\n", nameStr)
-		return
-	}
-
-	// Look up the encrypted KDK for this consumer
-	encKDK, ok := ks.am.GetEncryptedKDK(consumerKeyName)
-	if !ok {
-		fmt.Printf("NAC KeyServer: unauthorized consumer: %s\n", consumerKeyName)
-		return // Silently drop - unauthorized consumer gets no response
-	}
-
-	cfg := &ndn.DataConfig{
-		Freshness: optional.Some(time.Hour),
-	}
-
-	data, err := ks.engine.Spec().MakeData(
-		args.Interest.Name(),
-		cfg,
-		enc.Wire{encKDK},
-		ks.signer,
-	)
-	if err != nil {
-		fmt.Printf("NAC KeyServer: failed to create KDK response: %v\n", err)
-		return
-	}
-
-	args.Reply(data.Wire)
-}

--- a/std/nac/server.go
+++ b/std/nac/server.go
@@ -1,0 +1,143 @@
+package nac
+
+import (
+	"fmt"
+	"time"
+
+	enc "github.com/named-data/ndnd/std/encoding"
+	"github.com/named-data/ndnd/std/ndn"
+	"github.com/named-data/ndnd/std/types/optional"
+)
+
+// KeyServer serves NAC keys over NDN.
+//
+// It exposes:
+//   - KEK publicly at <credential-prefix>/E-KEY/<key-id> (any producer can fetch)
+//   - Encrypted KDKs at <kdk-name>/FOR/<consumer-key-name> (only authorized consumers)
+//
+// The key server wraps an AccessManager and attaches NDN Interest handlers.
+type KeyServer struct {
+	engine ndn.Engine
+	signer ndn.Signer
+	am     *AccessManager
+
+	credPrefix enc.Name
+}
+
+// NewKeyServer creates a NAC key server.
+func NewKeyServer(engine ndn.Engine, signer ndn.Signer, credentialPrefix string) (*KeyServer, error) {
+	am, err := NewAccessManager(credentialPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create access manager: %w", err)
+	}
+
+	prefix, err := enc.NameFromStr(credentialPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("invalid credential prefix: %w", err)
+	}
+
+	return &KeyServer{
+		engine:     engine,
+		signer:     signer,
+		am:         am,
+		credPrefix: prefix,
+	}, nil
+}
+
+// AccessManager returns the underlying access manager.
+func (ks *KeyServer) AccessManager() *AccessManager {
+	return ks.am
+}
+
+// Start registers NDN routes and attaches Interest handlers.
+func (ks *KeyServer) Start() error {
+	// Register the credential prefix route
+	if err := ks.engine.RegisterRoute(ks.credPrefix); err != nil {
+		return fmt.Errorf("failed to register route: %w", err)
+	}
+
+	// Attach KEK handler: <credential-prefix>/E-KEY
+	kekPrefix := ks.credPrefix.Append(enc.NewGenericComponent("E-KEY"))
+	if err := ks.engine.AttachHandler(kekPrefix, ks.onKEKInterest); err != nil {
+		return fmt.Errorf("failed to attach KEK handler: %w", err)
+	}
+
+	// Attach KDK handler: <credential-prefix>/D-KEY
+	kdkPrefix := ks.credPrefix.Append(enc.NewGenericComponent("D-KEY"))
+	if err := ks.engine.AttachHandler(kdkPrefix, ks.onKDKInterest); err != nil {
+		return fmt.Errorf("failed to attach KDK handler: %w", err)
+	}
+
+	fmt.Printf("NAC KeyServer started at %s\n", ks.credPrefix)
+	return nil
+}
+
+// Stop detaches Interest handlers.
+func (ks *KeyServer) Stop() error {
+	ks.engine.DetachHandler(ks.credPrefix.Append(enc.NewGenericComponent("E-KEY")))
+	ks.engine.DetachHandler(ks.credPrefix.Append(enc.NewGenericComponent("D-KEY")))
+	return nil
+}
+
+// onKEKInterest handles Interest for the public KEK.
+// Interest name: <credential-prefix>/E-KEY/<key-id>
+func (ks *KeyServer) onKEKInterest(args ndn.InterestHandlerArgs) {
+	kek := ks.am.KEK()
+	pubKeyBytes := kek.PublicKey.Bytes()
+
+	cfg := &ndn.DataConfig{
+		ContentType: optional.Some(ndn.ContentTypeKey),
+		Freshness:   optional.Some(time.Hour),
+	}
+
+	data, err := ks.engine.Spec().MakeData(
+		args.Interest.Name(),
+		cfg,
+		enc.Wire{pubKeyBytes},
+		ks.signer,
+	)
+	if err != nil {
+		fmt.Printf("NAC KeyServer: failed to create KEK response: %v\n", err)
+		return
+	}
+
+	args.Reply(data.Wire)
+}
+
+// onKDKInterest handles Interest for encrypted KDKs.
+// Interest name: <credential-prefix>/D-KEY/<key-id>/FOR/<consumer-key-name>
+func (ks *KeyServer) onKDKInterest(args ndn.InterestHandlerArgs) {
+	name := args.Interest.Name()
+
+	// Parse the consumer key name from the /FOR/ component
+	nameStr := name.String()
+	_, consumerKeyName, err := ParseEncryptedDataName(nameStr)
+	if err != nil {
+		fmt.Printf("NAC KeyServer: invalid KDK Interest name: %s\n", nameStr)
+		return
+	}
+
+	// Look up the encrypted KDK for this consumer
+	encKDK, ok := ks.am.GetEncryptedKDK(consumerKeyName)
+	if !ok {
+		fmt.Printf("NAC KeyServer: unauthorized consumer: %s\n", consumerKeyName)
+		return // Silently drop - unauthorized consumer gets no response
+	}
+
+	cfg := &ndn.DataConfig{
+		Freshness: optional.Some(time.Hour),
+	}
+
+	data, err := ks.engine.Spec().MakeData(
+		args.Interest.Name(),
+		cfg,
+		enc.Wire{encKDK},
+		ks.signer,
+	)
+	if err != nil {
+		fmt.Printf("NAC KeyServer: failed to create KDK response: %v\n", err)
+		return
+	}
+
+	args.Reply(data.Wire)
+}

--- a/std/security/ndncert/server/ca.go
+++ b/std/security/ndncert/server/ca.go
@@ -32,6 +32,8 @@ type CaServer struct {
 	// TODO: remove for final version, DNSResolver is only useful for testing with mock dns records
 	// 	if nil then net.LookupTXT is used
 	DNSResolver func(domain string) ([]string, error)
+	// MockDNS skips DNS verification entirely (for demo/testing)
+	MockDNS bool
 }
 
 func NewCaServer(engine ndn.Engine, config *CaConfig, caCertWire enc.Wire, signer ndn.Signer) (*CaServer, error) {
@@ -271,15 +273,11 @@ func (ca *CaServer) onNew(args ndn.InterestHandlerArgs) {
 	state.AeadCounter = ndncert.NewAeadCounter()
 	state.Status = StatusBeforeChallenge
 
-	selectedChallenge := ""
-	for _, ch := range ca.config.SupportedChallenges {
-		if ch.Name == ndncert.KwDns {
-			selectedChallenge = ch.Name
-			break
-		}
+	// advertise all supported challenges; client picks one in CHALLENGE
+	challengeNames := make([]string, len(ca.config.SupportedChallenges))
+	for i, ch := range ca.config.SupportedChallenges {
+		challengeNames[i] = ch.Name
 	}
-
-	state.ChallengeType = selectedChallenge
 
 	if err := ca.storage.Put(requestID, state); err != nil {
 		ca.sendError(args, 100, "internal error")
@@ -290,7 +288,7 @@ func (ca *CaServer) onNew(args ndn.InterestHandlerArgs) {
 		EcdhPub:   caEcdhKey.PublicKey().Bytes(),
 		Salt:      salt,
 		ReqId:     requestID,
-		Challenge: []string{selectedChallenge},
+		Challenge: challengeNames,
 	}
 
 	cfg := &ndn.DataConfig{
@@ -351,13 +349,30 @@ func (ca *CaServer) onChallenge(args ndn.InterestHandlerArgs) {
 		return
 	}
 
-	params, err := ca.decryptChallengeParams(appParam, state)
+	challengeName, params, err := ca.decryptChallengeParams(appParam, state)
 	if err != nil {
 		ca.sendError(args, 10, fmt.Sprintf("failed to decrypt parameters: %v", err))
 		return
 	}
 
-	// route to the rigt challenge handler
+	// on first CHALLENGE, client selects the challenge type
+	if state.Status == StatusBeforeChallenge && challengeName != "" {
+		// validate that CA supports this challenge
+		supported := false
+		for _, ch := range ca.config.SupportedChallenges {
+			if ch.Name == challengeName {
+				supported = true
+				break
+			}
+		}
+		if !supported {
+			ca.sendError(args, 11, fmt.Sprintf("unsupported challenge: %s", challengeName))
+			return
+		}
+		state.ChallengeType = challengeName
+	}
+
+	// route to the right challenge handler
 	var responseParams ndncert.ParamMap
 	var challengeStatus string
 	var challengeErr error
@@ -368,6 +383,7 @@ func (ca *CaServer) onChallenge(args ndn.InterestHandlerArgs) {
 	case ndncert.KwDns:
 		handler := &ChallengeDnsHandler{
 			DNSResolver: ca.DNSResolver,
+			MockDNS:     ca.MockDNS,
 		}
 		responseParams, challengeStatus, challengeErr = handler.HandleChallenge(params, state)
 		fmt.Printf("INFO: DNS challenge result: status=%s, success=%v\n", challengeStatus, state.Status == StatusSuccess)
@@ -545,11 +561,12 @@ func (ca *CaServer) sendError(args ndn.InterestHandlerArgs, code uint64, info st
 	args.Reply(data.Wire)
 }
 
-// decryptChallengeParams decrypts CHALLENGE request parameters using AEAD
-func (ca *CaServer) decryptChallengeParams(encParams enc.Wire, state *RequestState) (ndncert.ParamMap, error) {
+// decryptChallengeParams decrypts CHALLENGE request parameters using AEAD.
+// Returns the selected challenge name and parameter map.
+func (ca *CaServer) decryptChallengeParams(encParams enc.Wire, state *RequestState) (string, ndncert.ParamMap, error) {
 	cipherMsg, err := tlv.ParseCipherMsg(enc.NewWireView(encParams), false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse cipher message: %w", err)
+		return "", nil, fmt.Errorf("failed to parse cipher message: %w", err)
 	}
 
 	var aeadMsg ndncert.AeadMessage
@@ -557,16 +574,16 @@ func (ca *CaServer) decryptChallengeParams(encParams enc.Wire, state *RequestSta
 	// decrypt w/ request ID as additional data
 	plaintext, err := ndncert.AeadDecrypt(state.AesKey, aeadMsg, state.RequestID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt: %w", err)
+		return "", nil, fmt.Errorf("failed to decrypt: %w", err)
 	}
 
 	// parse decrypted ChallengeReq
 	chReq, err := tlv.ParseChallengeReq(enc.NewWireView(enc.Wire{plaintext}), false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse challenge request: %w", err)
+		return "", nil, fmt.Errorf("failed to parse challenge request: %w", err)
 	}
 
-	return chReq.Params, nil
+	return chReq.Challenge, chReq.Params, nil
 }
 
 // encryptChallengeResponse encrypts a full ChallengeRes structure using AEAD

--- a/std/security/ndncert/server/ca.go
+++ b/std/security/ndncert/server/ca.go
@@ -1,0 +1,318 @@
+package server
+
+import (
+	"crypto/ecdh"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"time"
+
+	enc "github.com/named-data/ndnd/std/encoding"
+	"github.com/named-data/ndnd/std/ndn"
+	"github.com/named-data/ndnd/std/security/ndncert"
+	"github.com/named-data/ndnd/std/security/ndncert/tlv"
+	"github.com/named-data/ndnd/std/types/optional"
+)
+
+type CaServer struct {
+	engine  ndn.Engine
+	config  *CaConfig
+	storage Storage
+	signer  ndn.Signer
+
+	caCertWire enc.Wire
+	caPrefix   enc.Name
+	caProfile  *tlv.CaProfile
+}
+
+func NewCaServer(engine ndn.Engine, config *CaConfig, caCertWire enc.Wire, signer ndn.Signer) (*CaServer, error) {
+	caPrefix, err := enc.NameFromStr(config.CaPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ca-prefix: %w", err)
+	}
+
+	caProfile, err := config.ToCaProfile(caCertWire)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CA profile: %w", err)
+	}
+
+	store := NewMemoryStorage()
+
+	server := &CaServer{
+		engine:     engine,
+		config:     config,
+		storage:    store,
+		signer:     signer,
+		caCertWire: caCertWire,
+		caPrefix:   caPrefix,
+		caProfile:  caProfile,
+	}
+
+	return server, nil
+}
+
+func (ca *CaServer) Start() error {
+	if err := ca.engine.RegisterRoute(ca.caPrefix); err != nil {
+		return fmt.Errorf("failed to register route: %w", err)
+	}
+
+	base := ca.caPrefix.Append(enc.NewGenericComponent("CA"))
+
+	infoPrefix := base.Append(enc.NewGenericComponent("INFO"))
+	if err := ca.engine.AttachHandler(infoPrefix, ca.onInfo); err != nil {
+		return fmt.Errorf("failed to attach INFO handler: %w", err)
+	}
+
+	probePrefix := base.Append(enc.NewGenericComponent("PROBE"))
+	if err := ca.engine.AttachHandler(probePrefix, ca.onProbe); err != nil {
+		return fmt.Errorf("failed to attach PROBE handler: %w", err)
+	}
+
+	newPrefix := base.Append(enc.NewGenericComponent("NEW"))
+	if err := ca.engine.AttachHandler(newPrefix, ca.onNew); err != nil {
+		return fmt.Errorf("failed to attach NEW handler: %w", err)
+	}
+
+	chPrefix := base.Append(enc.NewGenericComponent("CHALLENGE"))
+	if err := ca.engine.AttachHandler(chPrefix, ca.onChallenge); err != nil {
+		return fmt.Errorf("failed to attach CHALLENGE handler: %w", err)
+	}
+
+	return nil
+}
+
+func (ca *CaServer) Stop() error {
+	base := ca.caPrefix.Append(enc.NewGenericComponent("CA"))
+
+	ca.engine.DetachHandler(base.Append(enc.NewGenericComponent("INFO")))
+	ca.engine.DetachHandler(base.Append(enc.NewGenericComponent("PROBE")))
+	ca.engine.DetachHandler(base.Append(enc.NewGenericComponent("NEW")))
+	ca.engine.DetachHandler(base.Append(enc.NewGenericComponent("CHALLENGE")))
+
+	return nil
+}
+
+// handle INFO
+func (ca *CaServer) onInfo(args ndn.InterestHandlerArgs) {
+	profileWire := ca.caProfile.Encode()
+
+	cfg := &ndn.DataConfig{
+		Freshness: optional.Some(10 * time.Second),
+	}
+
+	data, err := ca.engine.Spec().MakeData(
+		args.Interest.Name(),
+		cfg,
+		profileWire,
+		ca.signer,
+	)
+	if err != nil {
+		// fmt.Printf("info response err: %v\n", err)
+		fmt.Printf("ERROR: Failed to create INFO response: %v\n", err)
+		return
+	}
+
+	args.Reply(data.Wire)
+}
+
+// PPROBE handler
+func (ca *CaServer) onProbe(args ndn.InterestHandlerArgs) {
+	appParam := args.Interest.AppParam()
+	if appParam == nil {
+		ca.sendError(args, 1, "missing application parameters")
+		return
+	}
+
+	probeReq, err := tlv.ParseProbeReq(enc.NewWireView(appParam), false)
+	if err != nil {
+		ca.sendError(args, 2, fmt.Sprintf("invalid PROBE request: %v", err))
+		return
+	}
+
+	vals := make([]*tlv.ProbeResVals, 0)
+
+	probeKeys := ca.config.GetProbeParamKeys()
+	if len(probeKeys) > 0 {
+		firstKey := probeKeys[0]
+		if paramValue, ok := probeReq.Params[firstKey]; ok {
+			suggestedName := ca.caPrefix.Append(enc.NewGenericComponent(string(paramValue)))
+			vals = append(vals, &tlv.ProbeResVals{
+				Response:        suggestedName,
+				MaxSuffixLength: optional.Some(uint64(2)),
+			})
+		}
+	}
+
+	probeRes := &tlv.ProbeRes{
+		Vals:           vals,
+		RedirectPrefix: nil,
+	}
+
+	cfg := &ndn.DataConfig{
+		Freshness: optional.Some(10 * time.Second),
+	}
+
+	data, err := ca.engine.Spec().MakeData(
+		args.Interest.Name(),
+		cfg,
+		probeRes.Encode(),
+		ca.signer,
+	)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create PROBE response: %v\n", err)
+		return
+	}
+
+	args.Reply(data.Wire)
+}
+
+// NEW handler
+func (ca *CaServer) onNew(args ndn.InterestHandlerArgs) {
+	appParam := args.Interest.AppParam()
+	if appParam == nil {
+		ca.sendError(args, 1, "missing application parameters")
+		return
+	}
+
+	newReq, err := tlv.ParseNewReq(enc.NewWireView(appParam), false)
+	if err != nil {
+		ca.sendError(args, 2, fmt.Sprintf("invalid NEW request: %v", err))
+		return
+	}
+
+	if len(newReq.EcdhPub) == 0 {
+		ca.sendError(args, 3, "missing ECDH public key")
+		return
+	}
+
+	if newReq.CertReq == nil {
+		ca.sendError(args, 4, "missing certificate request")
+		return
+	}
+
+	certReq, _, err := ca.engine.Spec().ReadData(enc.NewWireView(newReq.CertReq))
+	if err != nil {
+		ca.sendError(args, 5, fmt.Sprintf("invalid certificate request: %v", err))
+		return
+	}
+
+	requestID := make([]byte, 8)
+	if _, err := io.ReadFull(rand.Reader, requestID); err != nil {
+		ca.sendError(args, 100, "internal error")
+		return
+	}
+
+	caEcdhKey, err := ndncert.EcdhKeygen()
+	if err != nil {
+		ca.sendError(args, 100, "internal error")
+		return
+	}
+
+	salt := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		ca.sendError(args, 100, "internal error")
+		return
+	}
+
+	aesKeyBytes, err := ndncert.EcdhHkdf(caEcdhKey, newReq.EcdhPub, salt, requestID)
+	if err != nil {
+		ca.sendError(args, 6, fmt.Sprintf("ECDH key derivation failed: %v", err))
+		return
+	}
+
+	var aesKey [16]byte
+	copy(aesKey[:], aesKeyBytes)
+
+	state := NewRequestState(requestID, ca.caPrefix)
+	state.CertRequest = newReq.CertReq
+	state.RequestedCertName = certReq.Name()
+	state.ClientEcdhPub = newReq.EcdhPub
+	state.CaEcdhKey = caEcdhKey
+	state.Salt = salt
+	state.AesKey = aesKey
+	state.AeadCounter = ndncert.NewAeadCounter()
+	state.Status = StatusBeforeChallenge
+
+	selectedChallenge := ""
+	for _, ch := range ca.config.SupportedChallenges {
+		if ch.Name == ndncert.KwPin {
+			selectedChallenge = ch.Name
+			break
+		}
+	}
+	if selectedChallenge == "" {
+		ca.sendError(args, 7, "no supported challenge available")
+		return
+	}
+
+	state.ChallengeType = selectedChallenge
+
+	if err := ca.storage.Put(requestID, state); err != nil {
+		ca.sendError(args, 100, "internal error")
+		return
+	}
+
+	newRes := &tlv.NewRes{
+		EcdhPub:   caEcdhKey.PublicKey().Bytes(),
+		Salt:      salt,
+		ReqId:     requestID,
+		Challenge: []string{selectedChallenge},
+	}
+
+	cfg := &ndn.DataConfig{
+		Freshness: optional.Some(4 * time.Second),
+	}
+
+	data, err := ca.engine.Spec().MakeData(
+		args.Interest.Name(),
+		cfg,
+		newRes.Encode(),
+		ca.signer,
+	)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create NEW response: %v\n", err)
+		return
+	}
+
+	args.Reply(data.Wire)
+}
+
+// challenge handler (todo)
+func (ca *CaServer) onChallenge(args ndn.InterestHandlerArgs) {
+	ca.sendError(args, 99, "TODO")
+}
+
+func (ca *CaServer) sendError(args ndn.InterestHandlerArgs, code uint64, info string) {
+	errRes := &tlv.ErrorRes{
+		ErrCode: code,
+		ErrInfo: info,
+	}
+
+	cfg := &ndn.DataConfig{
+		Freshness: optional.Some(4 * time.Second),
+	}
+
+	data, err := ca.engine.Spec().MakeData(
+		args.Interest.Name(),
+		cfg,
+		errRes.Encode(),
+		ca.signer,
+	)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create error response: %v\n", err)
+		return
+	}
+
+	args.Reply(data.Wire)
+}
+
+func deriveEcdhKey(caKey *ecdh.PrivateKey, clientPubKey []byte, salt []byte, requestID []byte) ([16]byte, error) {
+	keyBytes, err := ndncert.EcdhHkdf(caKey, clientPubKey, salt, requestID)
+	if err != nil {
+		return [16]byte{}, err
+	}
+
+	var key [16]byte
+	copy(key[:], keyBytes)
+	return key, nil
+}

--- a/std/security/ndncert/server/ca.go
+++ b/std/security/ndncert/server/ca.go
@@ -9,9 +9,14 @@ import (
 
 	enc "github.com/named-data/ndnd/std/encoding"
 	"github.com/named-data/ndnd/std/ndn"
+	spec "github.com/named-data/ndnd/std/ndn/spec_2022"
+	"github.com/named-data/ndnd/std/object"
+	"github.com/named-data/ndnd/std/object/storage"
+	"github.com/named-data/ndnd/std/security"
 	"github.com/named-data/ndnd/std/security/ndncert"
 	"github.com/named-data/ndnd/std/security/ndncert/tlv"
 	"github.com/named-data/ndnd/std/types/optional"
+	"github.com/named-data/ndnd/std/utils"
 )
 
 type CaServer struct {
@@ -20,9 +25,13 @@ type CaServer struct {
 	storage Storage
 	signer  ndn.Signer
 
-	caCertWire enc.Wire
-	caPrefix   enc.Name
-	caProfile  *tlv.CaProfile
+	caCertWire  enc.Wire
+	caPrefix    enc.Name
+	caProfile   *tlv.CaProfile
+	objectStore ndn.Store // RDR store - needed for serving CA profile
+	// TODO: remove for final version, DNSResolver is only useful for testing with mock dns records
+	// 	if nil then net.LookupTXT is used
+	DNSResolver func(domain string) ([]string, error)
 }
 
 func NewCaServer(engine ndn.Engine, config *CaConfig, caCertWire enc.Wire, signer ndn.Signer) (*CaServer, error) {
@@ -37,15 +46,17 @@ func NewCaServer(engine ndn.Engine, config *CaConfig, caCertWire enc.Wire, signe
 	}
 
 	store := NewMemoryStorage()
+	objStore := storage.NewMemoryStore()
 
 	server := &CaServer{
-		engine:     engine,
-		config:     config,
-		storage:    store,
-		signer:     signer,
-		caCertWire: caCertWire,
-		caPrefix:   caPrefix,
-		caProfile:  caProfile,
+		engine:      engine,
+		config:      config,
+		storage:     store,
+		signer:      signer,
+		caCertWire:  caCertWire,
+		caPrefix:    caPrefix,
+		caProfile:   caProfile,
+		objectStore: objStore,
 	}
 
 	return server, nil
@@ -58,7 +69,22 @@ func (ca *CaServer) Start() error {
 
 	base := ca.caPrefix.Append(enc.NewGenericComponent("CA"))
 
+	// make CA profile now with RDR metadata
 	infoPrefix := base.Append(enc.NewGenericComponent("INFO"))
+	version := utils.MakeTimestamp(time.Now())
+	infoName := infoPrefix.Append(enc.NewVersionComponent(version))
+	profileWire := ca.caProfile.Encode()
+
+	_, err := object.Produce(ndn.ProduceArgs{
+		Name:            infoName,
+		Content:         profileWire,
+		FreshnessPeriod: 10 * time.Second,
+		NoMetadata:      false,
+	}, ca.objectStore, ca.signer)
+	if err != nil {
+		return fmt.Errorf("failed to produce CA profile: %w", err)
+	}
+
 	if err := ca.engine.AttachHandler(infoPrefix, ca.onInfo); err != nil {
 		return fmt.Errorf("failed to attach INFO handler: %w", err)
 	}
@@ -78,6 +104,10 @@ func (ca *CaServer) Start() error {
 		return fmt.Errorf("failed to attach CHALLENGE handler: %w", err)
 	}
 
+	if err := ca.engine.AttachHandler(ca.caPrefix, ca.onObjectFetch); err != nil {
+		return fmt.Errorf("failed to attach object fetch handler: %w", err)
+	}
+
 	return nil
 }
 
@@ -88,31 +118,38 @@ func (ca *CaServer) Stop() error {
 	ca.engine.DetachHandler(base.Append(enc.NewGenericComponent("PROBE")))
 	ca.engine.DetachHandler(base.Append(enc.NewGenericComponent("NEW")))
 	ca.engine.DetachHandler(base.Append(enc.NewGenericComponent("CHALLENGE")))
-
+	ca.engine.DetachHandler(ca.caPrefix)
 	return nil
 }
 
-// handle INFO
+// handle INFO - serves CA profile using RDR from object store
 func (ca *CaServer) onInfo(args ndn.InterestHandlerArgs) {
-	profileWire := ca.caProfile.Encode()
-
-	cfg := &ndn.DataConfig{
-		Freshness: optional.Some(10 * time.Second),
-	}
-
-	data, err := ca.engine.Spec().MakeData(
-		args.Interest.Name(),
-		cfg,
-		profileWire,
-		ca.signer,
-	)
+	data, err := ca.objectStore.Get(args.Interest.Name(), args.Interest.CanBePrefix())
 	if err != nil {
-		// fmt.Printf("info response err: %v\n", err)
-		fmt.Printf("ERROR: Failed to create INFO response: %v\n", err)
+		fmt.Printf("ERROR: failed to get INFO from store: %v\n", err)
+		return
+	}
+	if data == nil {
+		fmt.Printf("INFO: no data found for %s\n", args.Interest.Name())
 		return
 	}
 
-	args.Reply(data.Wire)
+	args.Reply(enc.Wire{data})
+}
+
+// serves data from object store
+func (ca *CaServer) onObjectFetch(args ndn.InterestHandlerArgs) {
+	data, err := ca.objectStore.Get(args.Interest.Name(), args.Interest.CanBePrefix())
+	if err != nil {
+		fmt.Printf("ERROR: failed to get object from store: %v\n", err)
+		return
+	}
+	if data == nil {
+		// Not found in store, don't reply (let other handlers try)
+		return
+	}
+
+	args.Reply(enc.Wire{data})
 }
 
 // PPROBE handler
@@ -195,6 +232,7 @@ func (ca *CaServer) onNew(args ndn.InterestHandlerArgs) {
 		ca.sendError(args, 5, fmt.Sprintf("invalid certificate request: %v", err))
 		return
 	}
+	fmt.Printf("INFO: received NEW request for identity: %s\n", certReq.Name())
 
 	requestID := make([]byte, 8)
 	if _, err := io.ReadFull(rand.Reader, requestID); err != nil {
@@ -235,14 +273,10 @@ func (ca *CaServer) onNew(args ndn.InterestHandlerArgs) {
 
 	selectedChallenge := ""
 	for _, ch := range ca.config.SupportedChallenges {
-		if ch.Name == ndncert.KwPin {
+		if ch.Name == ndncert.KwDns {
 			selectedChallenge = ch.Name
 			break
 		}
-	}
-	if selectedChallenge == "" {
-		ca.sendError(args, 7, "no supported challenge available")
-		return
 	}
 
 	state.ChallengeType = selectedChallenge
@@ -277,9 +311,214 @@ func (ca *CaServer) onNew(args ndn.InterestHandlerArgs) {
 	args.Reply(data.Wire)
 }
 
-// challenge handler (todo)
+// CHALLENGE handler
 func (ca *CaServer) onChallenge(args ndn.InterestHandlerArgs) {
-	ca.sendError(args, 99, "TODO")
+	// fetch request ID from Interest name: /<ca-prefix>/CA/CHALLENGE/<request-id>
+	name := args.Interest.Name()
+	baseLen := len(ca.caPrefix) + 2 // caPrefix + CA + CHALLENGE
+	if len(name) < baseLen+1 {
+		ca.sendError(args, 1, "missing request ID in name")
+		return
+	}
+
+	requestID := name[baseLen].Val
+	if len(requestID) == 0 {
+		ca.sendError(args, 1, "empty request ID")
+		return
+	}
+
+	fmt.Printf("INFO: received CHALLENGE request, ID=%x\n", requestID)
+
+	state, err := ca.storage.Get(requestID)
+	if err != nil {
+		ca.sendError(args, 100, "internal error")
+		return
+	}
+	if state == nil {
+		ca.sendError(args, 8, "request not found or expired")
+		return
+	}
+
+	if state.IsExpired() {
+		ca.sendError(args, 9, "request expired")
+		return
+	}
+
+	// parse and decrypt challenge parameters
+	appParam := args.Interest.AppParam()
+	if appParam == nil {
+		ca.sendError(args, 1, "missing application parameters")
+		return
+	}
+
+	params, err := ca.decryptChallengeParams(appParam, state)
+	if err != nil {
+		ca.sendError(args, 10, fmt.Sprintf("failed to decrypt parameters: %v", err))
+		return
+	}
+
+	// route to the rigt challenge handler
+	var responseParams ndncert.ParamMap
+	var challengeStatus string
+	var challengeErr error
+
+	fmt.Printf("INFO: processing %s challenge, status=%d\n", state.ChallengeType, state.Status)
+
+	switch state.ChallengeType {
+	case ndncert.KwDns:
+		handler := &ChallengeDnsHandler{
+			DNSResolver: ca.DNSResolver,
+		}
+		responseParams, challengeStatus, challengeErr = handler.HandleChallenge(params, state)
+		fmt.Printf("INFO: DNS challenge result: status=%s, success=%v\n", challengeStatus, state.Status == StatusSuccess)
+
+	default:
+		ca.sendError(args, 11, fmt.Sprintf("unsupported challenge type: %s", state.ChallengeType))
+		return
+	}
+
+	// challenge errors
+	if challengeErr != nil {
+		ca.sendError(args, 12, fmt.Sprintf("challenge error: %v", challengeErr))
+		return
+	}
+
+	// update request state
+	if err := ca.storage.Put(requestID, state); err != nil {
+		ca.sendError(args, 100, "internal error")
+		return
+	}
+
+	// build and send response based on challenge outcome
+	if state.Status == StatusSuccess {
+		fmt.Printf("INFO: challenge completed successfully, issuing cert\n")
+		cert, err := ca.issueCertificate(state)
+		if err != nil {
+			ca.sendError(args, 13, fmt.Sprintf("failed to issue certificate: %v", err))
+			return
+		}
+
+		// parse cert to get its name
+		certData, _, err := ca.engine.Spec().ReadData(enc.NewWireView(cert))
+		if err != nil {
+			ca.sendError(args, 15, fmt.Sprintf("failed to parse issued certificate: %v", err))
+			return
+		}
+		certName := certData.Name()
+
+		// store certificate in mem for client to fetch
+		err = ca.objectStore.Put(certName, cert.Join())
+		if err != nil {
+			ca.sendError(args, 16, fmt.Sprintf("failed to store certificate: %v", err))
+			return
+		}
+
+		fmt.Printf("INFO: Certificate issued and stored: %s\n", certName)
+
+		state.MarkSuccess(cert)
+		ca.storage.Put(requestID, state)
+
+		//ret success response w/ cert name
+		chRes := &tlv.ChallengeRes{
+			Status:         StatusSuccess,
+			ChalStatus:     optional.Some(challengeStatus),
+			CertName:       &spec.NameContainer{Name: certName},
+			ForwardingHint: nil,
+			Params:         responseParams,
+			RemainTries:    optional.None[uint64](),
+			RemainTime:     optional.None[uint64](),
+		}
+
+		encryptedResponse, err := ca.encryptChallengeResponse(chRes, state)
+		if err != nil {
+			ca.sendError(args, 14, fmt.Sprintf("failed to encrypt response: %v", err))
+			return
+		}
+
+		cfg := &ndn.DataConfig{
+			Freshness: optional.Some(4 * time.Second),
+		}
+
+		data, err := ca.engine.Spec().MakeData(
+			args.Interest.Name(),
+			cfg,
+			encryptedResponse,
+			ca.signer,
+		)
+		if err != nil {
+			fmt.Printf("ERROR: failed to create CHALLENGE response: %v\n", err)
+			return
+		}
+
+		args.Reply(data.Wire)
+		return
+	}
+
+	// challenge still in progress -> build complete ChallengeRes and encrypt it
+	chRes := &tlv.ChallengeRes{
+		Status:         state.Status,
+		ChalStatus:     optional.Some(challengeStatus),
+		RemainTries:    optional.Some(uint64(state.RemainingAttempts())),
+		RemainTime:     optional.None[uint64](),
+		CertName:       nil,
+		ForwardingHint: nil,
+		Params:         responseParams,
+	}
+
+	encryptedResponse, err := ca.encryptChallengeResponse(chRes, state)
+	if err != nil {
+		ca.sendError(args, 14, fmt.Sprintf("failed to encrypt response: %v", err))
+		return
+	}
+
+	cfg := &ndn.DataConfig{
+		Freshness: optional.Some(4 * time.Second),
+	}
+
+	// response content is the encrypted ChallengeRes (as CipherMsg)
+	data, err := ca.engine.Spec().MakeData(
+		args.Interest.Name(),
+		cfg,
+		encryptedResponse,
+		ca.signer,
+	)
+	if err != nil {
+		fmt.Printf("ERROR: failed to create CHALLENGE response: %v\n", err)
+		return
+	}
+
+	args.Reply(data.Wire)
+}
+
+// issueCertificate signs and issues a certificate for the given request
+func (ca *CaServer) issueCertificate(state *RequestState) (enc.Wire, error) {
+	// parse the cert request from state
+	certReqData, _, err := ca.engine.Spec().ReadData(enc.NewWireView(state.CertRequest))
+	if err != nil {
+		return enc.Wire{}, fmt.Errorf("failed to parse certificate request: %w", err)
+	}
+	maxValiditySec, err := ca.config.GetMaxValidityPeriodSeconds()
+	if err != nil {
+		return enc.Wire{}, fmt.Errorf("invalid max validity period: %w", err)
+	}
+
+	// issue the certificate
+	now := time.Now()
+	notBefore := now
+	notAfter := now.Add(time.Duration(maxValiditySec) * time.Second)
+
+	certWire, err := security.SignCert(security.SignCertArgs{
+		Signer:    ca.signer,
+		Data:      certReqData,
+		IssuerId:  enc.NewGenericComponent("NDNCERT"),
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+	})
+	if err != nil {
+		return enc.Wire{}, fmt.Errorf("failed to sign certificate: %w", err)
+	}
+
+	return certWire, nil
 }
 
 func (ca *CaServer) sendError(args ndn.InterestHandlerArgs, code uint64, info string) {
@@ -304,6 +543,43 @@ func (ca *CaServer) sendError(args ndn.InterestHandlerArgs, code uint64, info st
 	}
 
 	args.Reply(data.Wire)
+}
+
+// decryptChallengeParams decrypts CHALLENGE request parameters using AEAD
+func (ca *CaServer) decryptChallengeParams(encParams enc.Wire, state *RequestState) (ndncert.ParamMap, error) {
+	cipherMsg, err := tlv.ParseCipherMsg(enc.NewWireView(encParams), false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cipher message: %w", err)
+	}
+
+	var aeadMsg ndncert.AeadMessage
+	aeadMsg.FromTLV(cipherMsg)
+	// decrypt w/ request ID as additional data
+	plaintext, err := ndncert.AeadDecrypt(state.AesKey, aeadMsg, state.RequestID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt: %w", err)
+	}
+
+	// parse decrypted ChallengeReq
+	chReq, err := tlv.ParseChallengeReq(enc.NewWireView(enc.Wire{plaintext}), false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse challenge request: %w", err)
+	}
+
+	return chReq.Params, nil
+}
+
+// encryptChallengeResponse encrypts a full ChallengeRes structure using AEAD
+func (ca *CaServer) encryptChallengeResponse(chRes *tlv.ChallengeRes, state *RequestState) (enc.Wire, error) {
+	plaintext := chRes.Encode()
+
+	// encrypt w/ request ID as additional data
+	aeadMsg, err := ndncert.AeadEncrypt(state.AesKey, plaintext.Join(), state.RequestID, state.AeadCounter)
+	if err != nil {
+		return enc.Wire{}, fmt.Errorf("failed to encrypt: %w", err)
+	}
+
+	return aeadMsg.TLV().Encode(), nil
 }
 
 func deriveEcdhKey(caKey *ecdh.PrivateKey, clientPubKey []byte, salt []byte, requestID []byte) ([16]byte, error) {

--- a/std/security/ndncert/server/challenge_dns.go
+++ b/std/security/ndncert/server/challenge_dns.go
@@ -14,6 +14,8 @@ import (
 type ChallengeDnsHandler struct {
 	// override for testing, nil = net.LookupTXT
 	DNSResolver func(domain string) ([]string, error)
+	// MockDNS skips actual DNS verification (for demo/testing)
+	MockDNS bool
 }
 
 func (h *ChallengeDnsHandler) HandleChallenge(params ndncert.ParamMap, state *RequestState) (ndncert.ParamMap, string, error) {
@@ -44,6 +46,13 @@ func (h *ChallengeDnsHandler) HandleChallenge(params ndncert.ParamMap, state *Re
 		conf, ok := params[ndncert.KwConfirmation]
 		if !ok || string(conf) != "ready" {
 			return nil, "", fmt.Errorf("expected confirmation=ready")
+		}
+
+		// MockDNS: skip verification entirely
+		if h.MockDNS {
+			fmt.Printf("NDNCERT DNS (mock): auto-verifying domain\n")
+			state.Status = StatusSuccess
+			return nil, "", nil
 		}
 
 		domainBytes, _ := state.GetChallengeStateValue("domain")

--- a/std/security/ndncert/server/challenge_dns.go
+++ b/std/security/ndncert/server/challenge_dns.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/named-data/ndnd/std/security/ndncert"
+)
+
+// server-side DNS-01 challenge. requester proves domain ownership by putting a TXT record we can look up
+type ChallengeDnsHandler struct {
+	// override for testing, nil = net.LookupTXT
+	DNSResolver func(domain string) ([]string, error)
+}
+
+func (h *ChallengeDnsHandler) HandleChallenge(params ndncert.ParamMap, state *RequestState) (ndncert.ParamMap, string, error) {
+	if state.Status == StatusBeforeChallenge {
+		domain, ok := params[ndncert.KwDomain]
+		if !ok || len(domain) == 0 {
+			return nil, "", fmt.Errorf("missing domain")
+		}
+
+		token := make([]byte, 32)
+		if _, err := rand.Read(token); err != nil {
+			return nil, "", err
+		}
+		tokenB64 := base64.StdEncoding.EncodeToString(token)
+
+		state.SetChallengeStateValue("domain", domain)
+		state.SetChallengeStateValue("token", token)
+		state.Status = StatusChallenge
+
+		rec := fmt.Sprintf("%s.%s", ndncert.DNSPrefix, string(domain))
+		return ndncert.ParamMap{
+			ndncert.KwRecordName:    []byte(rec),
+			ndncert.KwExpectedValue: []byte(tokenB64),
+		}, "need-record", nil
+	}
+
+	if state.Status == StatusChallenge {
+		conf, ok := params[ndncert.KwConfirmation]
+		if !ok || string(conf) != "ready" {
+			return nil, "", fmt.Errorf("expected confirmation=ready")
+		}
+
+		domainBytes, _ := state.GetChallengeStateValue("domain")
+		tokenBytes, _ := state.GetChallengeStateValue("token")
+		if domainBytes == nil || tokenBytes == nil {
+			return nil, "", fmt.Errorf("challenge state missing")
+		}
+		domain := string(domainBytes)
+		expected := base64.StdEncoding.EncodeToString(tokenBytes)
+
+		rec := fmt.Sprintf("%s.%s", ndncert.DNSPrefix, domain)
+		records, err := h.lookupTXT(rec)
+
+		// build retry response in case we need it
+		retry := ndncert.ParamMap{
+			ndncert.KwRecordName:    []byte(rec),
+			ndncert.KwExpectedValue: []byte(expected),
+		}
+
+		if err != nil {
+			return retry, "wrong-record", nil
+		}
+
+		for _, r := range records {
+			if strings.TrimSpace(strings.Trim(r, "\"")) == expected {
+				state.Status = StatusSuccess
+				return nil, "", nil
+			}
+		}
+
+		return retry, "wrong-record", nil
+	}
+
+	return nil, "", fmt.Errorf("unexpected status %d", state.Status)
+}
+
+func (h *ChallengeDnsHandler) lookupTXT(name string) ([]string, error) {
+	if h.DNSResolver != nil {
+		return h.DNSResolver(name)
+	}
+	return net.LookupTXT(name)
+}

--- a/std/security/ndncert/server/challenge_dns_test.go
+++ b/std/security/ndncert/server/challenge_dns_test.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/named-data/ndnd/std/security/ndncert"
+)
+
+func TestChallengeDnsHandler_InitialRequest(t *testing.T) {
+	handler := &ChallengeDnsHandler{}
+	state := NewRequestState([]byte("test-req-id"), nil)
+
+	params := ndncert.ParamMap{
+		ndncert.KwDomain: []byte("example.com"),
+	}
+
+	responseParams, status, err := handler.HandleChallenge(params, state)
+	if err != nil {
+		t.Fatalf("HandleChallenge failed: %v", err)
+	}
+
+	if status != "need-record" {
+		t.Errorf("Expected status 'need-record', got '%s'", status)
+	}
+
+	if state.Status != StatusChallenge {
+		t.Errorf("Expected state status StatusChallenge, got %d", state.Status)
+	}
+
+	recordName, ok := responseParams[ndncert.KwRecordName]
+	if !ok {
+		t.Fatal("Response missing record-name parameter")
+	}
+
+	expectedValue, ok := responseParams[ndncert.KwExpectedValue]
+	if !ok {
+		t.Fatal("Response missing expected-value parameter")
+	}
+
+	recordNameStr := string(recordName)
+	if recordNameStr != "_ndncert-challenge.example.com" {
+		t.Errorf("Expected record name '_ndncert-challenge.example.com', got '%s'", recordNameStr)
+	}
+
+	if len(expectedValue) == 0 {
+		t.Error("Expected value should not be empty")
+	}
+
+	t.Logf("Record name: %s", recordNameStr)
+	t.Logf("Expected value: %s", string(expectedValue))
+}
+
+func TestChallengeDnsHandler_SuccessfulVerification(t *testing.T) {
+	handler := &ChallengeDnsHandler{
+		DNSResolver: func(domain string) ([]string, error) {
+			return []string{"test-token-base64"}, nil
+		},
+	}
+
+	state := NewRequestState([]byte("test-req-id"), nil)
+	state.Status = StatusChallenge
+	state.SetChallengeStateValue("domain", []byte("example.com"))
+	state.SetChallengeStateValue("token", []byte("test-token-decoded"))
+
+	params := ndncert.ParamMap{
+		ndncert.KwConfirmation: []byte("ready"),
+	}
+
+	_, _, err := handler.HandleChallenge(params, state)
+	if err != nil {
+		t.Logf("HandleChallenge returned error: %v", err)
+	}
+}
+
+func TestChallengeDnsHandler_FailedVerification(t *testing.T) {
+	handler := &ChallengeDnsHandler{
+		DNSResolver: func(domain string) ([]string, error) {
+			return []string{"wrong-token"}, nil
+		},
+	}
+
+	state := NewRequestState([]byte("test-req-id"), nil)
+	state.Status = StatusChallenge
+	state.SetChallengeStateValue("domain", []byte("example.com"))
+	state.SetChallengeStateValue("token", []byte("correct-token-bytes"))
+
+	params := ndncert.ParamMap{
+		ndncert.KwConfirmation: []byte("ready"),
+	}
+
+	responseParams, status, err := handler.HandleChallenge(params, state)
+	if err != nil {
+		t.Fatalf("HandleChallenge failed: %v", err)
+	}
+
+	if status != "wrong-record" {
+		t.Errorf("Expected status 'wrong-record', got '%s'", status)
+	}
+
+	if state.Status != StatusChallenge {
+		t.Errorf("Expected state to remain in StatusChallenge, got %d", state.Status)
+	}
+
+	if _, ok := responseParams[ndncert.KwRecordName]; !ok {
+		t.Error("Response should include record-name for retry")
+	}
+}
+
+func TestChallengeDnsHandler_MissingDomain(t *testing.T) {
+	handler := &ChallengeDnsHandler{}
+	state := NewRequestState([]byte("test-req-id"), nil)
+
+	params := ndncert.ParamMap{}
+
+	_, _, err := handler.HandleChallenge(params, state)
+	if err == nil {
+		t.Fatal("Expected error for missing domain parameter")
+	}
+
+	if err.Error() != "missing domain" {
+		t.Errorf("Expected 'missing domain' error, got: %v", err)
+	}
+}
+
+func TestChallengeDnsHandler_DNSLookupFailure(t *testing.T) {
+	handler := &ChallengeDnsHandler{
+		DNSResolver: func(domain string) ([]string, error) {
+			return nil, errors.New("DNS lookup failed")
+		},
+	}
+
+	state := NewRequestState([]byte("test-req-id"), nil)
+	state.Status = StatusChallenge
+	state.SetChallengeStateValue("domain", []byte("example.com"))
+	state.SetChallengeStateValue("token", []byte("test-token"))
+
+	params := ndncert.ParamMap{
+		ndncert.KwConfirmation: []byte("ready"),
+	}
+
+	responseParams, status, err := handler.HandleChallenge(params, state)
+	if err != nil {
+		t.Fatalf("HandleChallenge failed: %v", err)
+	}
+
+	if status != "wrong-record" {
+		t.Errorf("Expected status 'wrong-record' on DNS failure, got '%s'", status)
+	}
+
+	if _, ok := responseParams[ndncert.KwRecordName]; !ok {
+		t.Error("Response should include record-name for retry")
+	}
+}

--- a/std/security/ndncert/server/config.go
+++ b/std/security/ndncert/server/config.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	enc "github.com/named-data/ndnd/std/encoding"
+	"github.com/named-data/ndnd/std/security/ndncert/tlv"
+	spec "github.com/named-data/ndnd/std/ndn/spec_2022"
+)
+
+type ProbeParam struct {
+	Key string `json:"probe-parameter-key"`
+}
+
+type ChallengeConfig struct {
+	Name string `json:"challenge"`
+}
+
+type RedirectConfig struct {
+	CaPrefix    string `json:"ca-prefix"`
+	Certificate string `json:"certificate"`
+	PolicyType  string `json:"policy-type"`
+	PolicyParam string `json:"policy-param"`
+}
+
+type CaConfig struct {
+	CaPrefix           string            `json:"ca-prefix"`
+	CaInfo             string            `json:"ca-info"`
+	MaxValidityPeriod  string            `json:"max-validity-period"`
+	MaxSuffixLength    string            `json:"max-suffix-length"`
+	ProbeParameters    []ProbeParam      `json:"probe-parameters"`
+	SupportedChallenges []ChallengeConfig `json:"supported-challenges"`
+	RedirectTo         []RedirectConfig  `json:"redirect-to"`
+
+	CaCertPath string `json:"-"`
+	CaKeyPath  string `json:"-"`
+}
+
+func LoadConfig(path string) (*CaConfig, error) {
+	// log.Printf("loading ca config: %s", path)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var cfg CaConfig
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config json: %w", err)
+	}
+
+	if cfg.CaPrefix == "" {
+		return nil, fmt.Errorf("ca-prefix is required")
+	}
+	if cfg.MaxValidityPeriod == "" {
+		return nil, fmt.Errorf("max-validity-period is required")
+	}
+
+	return &cfg, nil
+}
+
+func (c *CaConfig) ToCaProfile(caCertWire enc.Wire) (*tlv.CaProfile, error) {
+	caName, err := enc.NameFromStr(c.CaPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ca-prefix: %w", err)
+	}
+
+	mv, err := strconv.ParseUint(c.MaxValidityPeriod, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid max-validity-period: %w", err)
+	}
+
+	pkeys := make([]string, len(c.ProbeParameters))
+	for i, p := range c.ProbeParameters {
+		pkeys[i] = p.Key
+	}
+
+	return &tlv.CaProfile{
+		CaPrefix:       &spec.NameContainer{Name: caName},
+		CaInfo:         c.CaInfo,
+		ParamKey:       pkeys,
+		MaxValidPeriod: mv,
+		CaCert:         caCertWire,
+	}, nil
+}
+
+func (c *CaConfig) GetMaxValidityPeriodSeconds() (uint64, error) {
+	return strconv.ParseUint(c.MaxValidityPeriod, 10, 64)
+}
+
+func (c *CaConfig) GetMaxSuffixLength() (uint64, error) {
+	if c.MaxSuffixLength == "" {
+		return 2, nil
+	}
+	return strconv.ParseUint(c.MaxSuffixLength, 10, 64)
+}
+
+func (c *CaConfig) SupportsChallenge(name string) bool {
+	for _, ch := range c.SupportedChallenges {
+		if ch.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *CaConfig) GetProbeParamKeys() []string {
+	keys := make([]string, len(c.ProbeParameters))
+	for i, p := range c.ProbeParameters {
+		keys[i] = p.Key
+	}
+	return keys
+}

--- a/std/security/ndncert/server/config_test.go
+++ b/std/security/ndncert/server/config_test.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_CPPCompatibility(t *testing.T) {
+	testConfig := `{
+  "ca-prefix": "/example",
+  "ca-info": "An example NDNCERT CA",
+  "max-validity-period": "1296000",
+  "max-suffix-length": "2",
+  "probe-parameters": [
+    {
+      "probe-parameter-key": "email"
+    }
+  ],
+  "supported-challenges": [
+    {
+      "challenge": "pin"
+    },
+    {
+      "challenge": "email"
+    }
+  ]
+}`
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test-ca.conf")
+	err := os.WriteFile(configPath, []byte(testConfig), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if config.CaPrefix != "/example" {
+		t.Errorf("Expected ca-prefix '/example', got '%s'", config.CaPrefix)
+	}
+
+	if config.CaInfo != "An example NDNCERT CA" {
+		t.Errorf("Expected ca-info 'An example NDNCERT CA', got '%s'", config.CaInfo)
+	}
+
+	if config.MaxValidityPeriod != "1296000" {
+		t.Errorf("Expected max-validity-period '1296000', got '%s'", config.MaxValidityPeriod)
+	}
+
+	if len(config.ProbeParameters) != 1 {
+		t.Errorf("Expected 1 probe parameter, got %d", len(config.ProbeParameters))
+	}
+
+	if len(config.SupportedChallenges) != 2 {
+		t.Errorf("Expected 2 supported challenges, got %d", len(config.SupportedChallenges))
+	}
+
+	if !config.SupportsChallenge("pin") {
+		t.Error("Expected to support 'pin' challenge")
+	}
+
+	if !config.SupportsChallenge("email") {
+		t.Error("Expected to support 'email' challenge")
+	}
+
+	if config.SupportsChallenge("dns") {
+		t.Error("Should not support 'dns' challenge")
+	}
+
+	maxValidity, err := config.GetMaxValidityPeriodSeconds()
+	if err != nil {
+		t.Fatalf("Failed to get max validity period: %v", err)
+	}
+	if maxValidity != 1296000 {
+		t.Errorf("Expected max validity 1296000, got %d", maxValidity)
+	}
+}
+
+func TestLoadConfig_SampleFile(t *testing.T) {
+	configPath := filepath.Join("..", "..", "..", "examples", "ndncert", "ca.conf.sample")
+
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load sample config: %v", err)
+	}
+
+	if config.CaPrefix == "" {
+		t.Fatalf("Expected ca-prefix to be set")
+	}
+	if config.MaxValidityPeriod == "" {
+		t.Fatalf("Expected max-validity-period to be set")
+	}
+	if len(config.SupportedChallenges) == 0 {
+		t.Fatalf("Expected at least one supported challenge")
+	}
+}

--- a/std/security/ndncert/server/state.go
+++ b/std/security/ndncert/server/state.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"crypto/ecdh"
+	"time"
+
+	enc "github.com/named-data/ndnd/std/encoding"
+	"github.com/named-data/ndnd/std/security/ndncert"
+)
+
+const (
+	StatusBeforeChallenge = uint64(0)
+	StatusChallenge       = uint64(1)
+	StatusPending         = uint64(2)
+	StatusSuccess         = uint64(3)
+	StatusFailure         = uint64(4)
+)
+
+type RequestState struct {
+	RequestID []byte
+	CaPrefix  enc.Name
+	Status    uint64
+
+	ChallengeType     string
+	ChallengeStatus   string
+	ChallengeAttempts int
+	MaxChallengeAttempts int
+	ChallengeState    map[string][]byte
+
+	CertRequest       enc.Wire
+	RequestedCertName enc.Name
+
+	ClientEcdhPub []byte
+	CaEcdhKey     *ecdh.PrivateKey
+	Salt          []byte
+	AesKey        [16]byte
+	AeadCounter   *ndncert.AeadCounter
+
+	IssuedCert enc.Wire
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ExpiresAt time.Time
+}
+
+func NewRequestState(requestID []byte, caPrefix enc.Name) *RequestState {
+	now := time.Now()
+	return &RequestState{
+		RequestID:            requestID,
+		CaPrefix:             caPrefix,
+		Status:               StatusBeforeChallenge,
+		ChallengeAttempts:    0,
+		MaxChallengeAttempts: 3,
+		ChallengeState:       make(map[string][]byte),
+		CreatedAt:            now,
+		UpdatedAt:            now,
+		ExpiresAt:            now.Add(24 * time.Hour),
+	}
+}
+
+func (r *RequestState) IncrementAttempts() bool {
+	r.ChallengeAttempts++
+	r.UpdatedAt = time.Now()
+	return r.ChallengeAttempts >= r.MaxChallengeAttempts
+}
+
+func (r *RequestState) RemainingAttempts() int {
+	remaining := r.MaxChallengeAttempts - r.ChallengeAttempts
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func (r *RequestState) IsExpired() bool {
+	return time.Now().After(r.ExpiresAt)
+}
+
+func (r *RequestState) SetChallengeStateValue(key string, value []byte) {
+	r.ChallengeState[key] = value
+	r.UpdatedAt = time.Now()
+}
+
+func (r *RequestState) GetChallengeStateValue(key string) ([]byte, bool) {
+	val, ok := r.ChallengeState[key]
+	return val, ok
+}
+
+func (r *RequestState) MarkSuccess(issuedCert enc.Wire) {
+	r.Status = StatusSuccess
+	r.IssuedCert = issuedCert
+	r.UpdatedAt = time.Now()
+}
+
+func (r *RequestState) MarkFailure(reason string) {
+	r.Status = StatusFailure
+	r.ChallengeStatus = reason
+	r.UpdatedAt = time.Now()
+}

--- a/std/security/ndncert/server/state.go
+++ b/std/security/ndncert/server/state.go
@@ -21,11 +21,11 @@ type RequestState struct {
 	CaPrefix  enc.Name
 	Status    uint64
 
-	ChallengeType     string
-	ChallengeStatus   string
-	ChallengeAttempts int
+	ChallengeType        string
+	ChallengeStatus      string
+	ChallengeAttempts    int
 	MaxChallengeAttempts int
-	ChallengeState    map[string][]byte
+	ChallengeState       map[string][]byte
 
 	CertRequest       enc.Wire
 	RequestedCertName enc.Name

--- a/std/security/ndncert/server/storage.go
+++ b/std/security/ndncert/server/storage.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// TODO: do we want persistant storage? right now everything is tracked in memory in a request id -> state map
+
+type Storage interface {
+	Put(requestID []byte, state *RequestState) error
+	Get(requestID []byte) (*RequestState, error)
+	Delete(requestID []byte) error
+	List() ([][]byte, error)
+	CleanExpired() (int, error)
+}
+
+type MemoryStorage struct {
+	mu    sync.RWMutex
+	store map[string]*RequestState
+}
+
+func NewMemoryStorage() *MemoryStorage {
+	s := &MemoryStorage{
+		store: make(map[string]*RequestState),
+	}
+
+	go s.cleanupLoop()
+	return s
+}
+
+func (m *MemoryStorage) Put(requestID []byte, state *RequestState) error {
+	if requestID == nil {
+		return fmt.Errorf("requestID cannot be nil")
+	}
+	if state == nil {
+		return fmt.Errorf("state cannot be nil")
+	}
+
+	key := string(requestID)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.store[key] = state
+	return nil
+}
+
+func (m *MemoryStorage) Get(requestID []byte) (*RequestState, error) {
+	if requestID == nil {
+		return nil, fmt.Errorf("requestID cannot be nil")
+	}
+
+	key := string(requestID)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state, ok := m.store[key]
+	if !ok {
+		return nil, nil
+	}
+
+	if state.IsExpired() {
+		return nil, nil
+	}
+
+	return state, nil
+}
+
+func (m *MemoryStorage) Delete(requestID []byte) error {
+	if requestID == nil {
+		return fmt.Errorf("requestID cannot be nil")
+	}
+
+	key := string(requestID)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.store, key)
+	return nil
+}
+
+func (m *MemoryStorage) List() ([][]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ids := make([][]byte, 0, len(m.store))
+	for key := range m.store {
+		ids = append(ids, []byte(key))
+	}
+
+	return ids, nil
+}
+
+func (m *MemoryStorage) CleanExpired() (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	deleted := 0
+
+	for key, state := range m.store {
+		if now.After(state.ExpiresAt) {
+			delete(m.store, key)
+			deleted++
+		}
+	}
+
+	return deleted, nil
+}
+
+func (m *MemoryStorage) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		// log.Printf("ndncert cleanup: %d", m.Count())
+		m.CleanExpired()
+	}
+}
+
+// byte-wise lookup since map keys are strings
+func (m *MemoryStorage) FindByRequestID(requestID []byte) (*RequestState, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for key, state := range m.store {
+		if bytes.Equal([]byte(key), requestID) {
+			if !state.IsExpired() {
+				return state, nil
+			}
+			return nil, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (m *MemoryStorage) Count() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.store)
+}

--- a/tools/catchunks.go
+++ b/tools/catchunks.go
@@ -19,10 +19,11 @@ import (
 )
 
 type CatChunks struct {
-	nacKey    string // hex X25519 private key for NAC decryption
-	nacCred   string // NAC credential prefix (for KDK fetch)
-	nacKeyID  string // hex KEK ID (for constructing KDK name)
-	nacIdent  string // consumer key name (NDNCERT identity)
+	nacKey     string // hex X25519 private key for NAC decryption
+	nacAccess  string // NAC access prefix (for KDK fetch)
+	nacDataset string // NAC dataset name
+	nacKeyID   string // hex KEK ID (for constructing KDK name)
+	nacIdent   string // consumer key name (NDNCERT identity)
 }
 
 // (AI GENERATED DESCRIPTION): Creates a Cobra command that retrieves the data object for a given name prefix and writes its content to standard output.
@@ -44,7 +45,8 @@ then decrypts the content before writing to stdout.`,
 	}
 
 	cmd.Flags().StringVar(&cc.nacKey, "nac-key", "", "NAC X25519 private key (hex) for decryption")
-	cmd.Flags().StringVar(&cc.nacCred, "nac-cred", "", "NAC credential prefix (for KDK fetch)")
+	cmd.Flags().StringVar(&cc.nacAccess, "nac-access", "", "NAC access prefix (for KDK fetch)")
+	cmd.Flags().StringVar(&cc.nacDataset, "nac-dataset", "default", "NAC dataset name")
 	cmd.Flags().StringVar(&cc.nacKeyID, "nac-kek-id", "", "NAC KEK ID (hex, for constructing KDK name)")
 	cmd.Flags().StringVar(&cc.nacIdent, "nac-ident", "", "Consumer key name (NDNCERT identity)")
 
@@ -115,8 +117,8 @@ func (cc *CatChunks) run(_ *cobra.Command, args []string) {
 
 	// If NAC decryption is enabled
 	if cc.nacKey != "" {
-		if cc.nacCred == "" || cc.nacKeyID == "" || cc.nacIdent == "" {
-			log.Fatal(cc, "--nac-cred, --nac-kek-id, and --nac-ident are required with --nac-key")
+		if cc.nacAccess == "" || cc.nacKeyID == "" || cc.nacIdent == "" {
+			log.Fatal(cc, "--nac-access, --nac-kek-id, and --nac-ident are required with --nac-key")
 			return
 		}
 
@@ -156,8 +158,7 @@ func (cc *CatChunks) run(_ *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Encrypted CK: %d bytes\n", len(encCKBytes))
 
 		// Fetch the encrypted KDK from the NAC server
-		kdkName := nac.KDKName(cc.nacCred, kekID)
-		kdkForName := nac.EncryptedDataName(kdkName, cc.nacIdent)
+		kdkForName := nac.EncryptedKDKName(cc.nacAccess, cc.nacDataset, kekID, cc.nacIdent)
 		fmt.Fprintf(os.Stderr, "Fetching KDK from %s...\n", kdkForName)
 
 		kdkNdnName, _ := enc.NameFromStr(kdkForName)

--- a/tools/catchunks.go
+++ b/tools/catchunks.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"time"
@@ -8,28 +9,46 @@ import (
 	enc "github.com/named-data/ndnd/std/encoding"
 	"github.com/named-data/ndnd/std/engine"
 	"github.com/named-data/ndnd/std/log"
+	"github.com/named-data/ndnd/std/nac"
 	"github.com/named-data/ndnd/std/ndn"
 	"github.com/named-data/ndnd/std/object"
 	"github.com/named-data/ndnd/std/object/storage"
+	"github.com/named-data/ndnd/std/types/optional"
+	"github.com/named-data/ndnd/std/utils"
 	"github.com/spf13/cobra"
 )
 
-type CatChunks struct{}
+type CatChunks struct {
+	nacKey    string // hex X25519 private key for NAC decryption
+	nacCred   string // NAC credential prefix (for KDK fetch)
+	nacKeyID  string // hex KEK ID (for constructing KDK name)
+	nacIdent  string // consumer key name (NDNCERT identity)
+}
 
 // (AI GENERATED DESCRIPTION): Creates a Cobra command that retrieves the data object for a given name prefix and writes its content to standard output.
 func CmdCatChunks() *cobra.Command {
 	cc := CatChunks{}
 
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		GroupID: "tools",
 		Use:     "cat PREFIX",
 		Short:   "Retrieve object under a name prefix",
 		Long: `Retrieve an object with the specified name.
-The object contents are written to stdout on success.`,
+The object contents are written to stdout on success.
+
+With NAC flags, also fetches the encrypted content key and KDK,
+then decrypts the content before writing to stdout.`,
 		Args:    cobra.ExactArgs(1),
 		Example: `  ndnd cat /my/example/data > data.bin`,
 		Run:     cc.run,
 	}
+
+	cmd.Flags().StringVar(&cc.nacKey, "nac-key", "", "NAC X25519 private key (hex) for decryption")
+	cmd.Flags().StringVar(&cc.nacCred, "nac-cred", "", "NAC credential prefix (for KDK fetch)")
+	cmd.Flags().StringVar(&cc.nacKeyID, "nac-kek-id", "", "NAC KEK ID (hex, for constructing KDK name)")
+	cmd.Flags().StringVar(&cc.nacIdent, "nac-ident", "", "Consumer key name (NDNCERT identity)")
+
+	return cmd
 }
 
 // (AI GENERATED DESCRIPTION): Returns the literal string `"cat"` as the textual representation of a `CatChunks` instance.
@@ -88,16 +107,95 @@ func (cc *CatChunks) run(_ *cobra.Command, args []string) {
 		return
 	}
 
-	// write object to stdout
-	byteCount := 0
+	// Collect content bytes
+	var contentBytes []byte
 	for _, chunk := range state.Content() {
-		os.Stdout.Write(chunk)
-		byteCount += len(chunk)
+		contentBytes = append(contentBytes, chunk...)
 	}
+
+	// If NAC decryption is enabled
+	if cc.nacKey != "" {
+		if cc.nacCred == "" || cc.nacKeyID == "" || cc.nacIdent == "" {
+			log.Fatal(cc, "--nac-cred, --nac-kek-id, and --nac-ident are required with --nac-key")
+			return
+		}
+
+		privKeyBytes, err := hex.DecodeString(cc.nacKey)
+		if err != nil {
+			log.Fatal(cc, "Invalid NAC private key hex", "err", err)
+			return
+		}
+		privKey, err := nac.DeserializePrivateKey(privKeyBytes)
+		if err != nil {
+			log.Fatal(cc, "Invalid NAC X25519 private key", "err", err)
+			return
+		}
+		kekID, err := hex.DecodeString(cc.nacKeyID)
+		if err != nil {
+			log.Fatal(cc, "Invalid KEK ID hex", "err", err)
+			return
+		}
+
+		// Fetch the encrypted CK from <prefix>/CK
+		ckName := name.Append(enc.NewGenericComponent("CK"))
+		fmt.Fprintf(os.Stderr, "Fetching encrypted CK from %s...\n", ckName)
+		ckDone := make(chan ndn.ConsumeState)
+		cli.ConsumeExt(ndn.ConsumeExtArgs{
+			Name:     ckName,
+			Callback: func(s ndn.ConsumeState) { ckDone <- s },
+		})
+		ckState := <-ckDone
+		if ckState.Error() != nil {
+			log.Fatal(cc, "Failed to fetch encrypted CK", "err", ckState.Error())
+			return
+		}
+		var encCKBytes []byte
+		for _, chunk := range ckState.Content() {
+			encCKBytes = append(encCKBytes, chunk...)
+		}
+		fmt.Fprintf(os.Stderr, "Encrypted CK: %d bytes\n", len(encCKBytes))
+
+		// Fetch the encrypted KDK from the NAC server
+		kdkName := nac.KDKName(cc.nacCred, kekID)
+		kdkForName := nac.EncryptedDataName(kdkName, cc.nacIdent)
+		fmt.Fprintf(os.Stderr, "Fetching KDK from %s...\n", kdkForName)
+
+		kdkNdnName, _ := enc.NameFromStr(kdkForName)
+		kdkCh := make(chan ndn.ExpressCallbackArgs, 1)
+		kdkInterest, _ := app.Spec().MakeInterest(kdkNdnName, &ndn.InterestConfig{
+			Lifetime: optional.Some(10 * time.Second),
+			Nonce:    utils.ConvertNonce(app.Timer().Nonce()),
+		}, nil, nil)
+		app.Express(kdkInterest, func(args ndn.ExpressCallbackArgs) { kdkCh <- args })
+		kdkResult := <-kdkCh
+		if kdkResult.Result != ndn.InterestResultData {
+			log.Fatal(cc, "Failed to fetch KDK", "result", kdkResult.Result)
+			return
+		}
+		encKDKBytes := kdkResult.Data.Content().Join()
+		fmt.Fprintf(os.Stderr, "Encrypted KDK: %d bytes\n", len(encKDKBytes))
+
+		// Decrypt the chain: KDK -> CK -> content
+		decryptor := nac.NewDecryptor(cc.nacIdent, privKey)
+		plaintext, err := decryptor.Decrypt(
+			&nac.EncryptedContent{EncryptedPayload: contentBytes},
+			&nac.EncryptedCK{EncryptedPayload: encCKBytes},
+			encKDKBytes,
+		)
+		if err != nil {
+			log.Fatal(cc, "NAC decryption failed", "err", err)
+			return
+		}
+		contentBytes = plaintext
+		fmt.Fprintf(os.Stderr, "Decrypted: %d bytes\n", len(plaintext))
+	}
+
+	// write to stdout
+	os.Stdout.Write(contentBytes)
 
 	// statistics
 	fmt.Fprintf(os.Stderr, "Object fetched %s\n", state.Name())
-	fmt.Fprintf(os.Stderr, "Content: %d bytes\n", byteCount)
+	fmt.Fprintf(os.Stderr, "Content: %d bytes\n", len(contentBytes))
 	fmt.Fprintf(os.Stderr, "Time taken: %s\n", t2.Sub(t1))
-	fmt.Fprintf(os.Stderr, "Throughput: %f Mbit/s\n", float64(byteCount*8)/t2.Sub(t1).Seconds()/1e6)
+	fmt.Fprintf(os.Stderr, "Throughput: %f Mbit/s\n", float64(len(contentBytes)*8)/t2.Sub(t1).Seconds()/1e6)
 }

--- a/tools/nac.go
+++ b/tools/nac.go
@@ -2,17 +2,23 @@ package tools
 
 import (
 	"crypto/ecdh"
+	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	enc "github.com/named-data/ndnd/std/encoding"
 	"github.com/named-data/ndnd/std/engine"
 	"github.com/named-data/ndnd/std/log"
 	"github.com/named-data/ndnd/std/nac"
+	"github.com/named-data/ndnd/std/ndn"
+	sec "github.com/named-data/ndnd/std/security"
 	sig "github.com/named-data/ndnd/std/security/signer"
+	"github.com/named-data/ndnd/std/types/optional"
+	"github.com/named-data/ndnd/std/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -49,6 +55,7 @@ The key server serves:
 
 	cmd.AddCommand(cmdNacEncrypt())
 	cmd.AddCommand(cmdNacDecrypt())
+	cmd.AddCommand(cmdNacEnroll())
 
 	return cmd
 }
@@ -98,7 +105,9 @@ func (ns *NacServer) runServe(_ *cobra.Command, args []string) {
 	}
 
 	kek := ks.AccessManager().KEK()
+	kekPubBytes, _ := nac.SerializePublicKey(kek.PublicKey)
 	fmt.Printf("KEK ID: %s\n", hex.EncodeToString(kek.ID))
+	fmt.Printf("KEK Public Key: %s\n", hex.EncodeToString(kekPubBytes))
 	fmt.Printf("KEK Name: %s\n", nac.KEKName(credPrefix, kek.ID))
 
 	// start serving keys
@@ -260,4 +269,132 @@ func runNacDecrypt(_ *cobra.Command, args []string) {
 
 	os.Stdout.Write(plaintext)
 	fmt.Fprintf(os.Stderr, "Decrypted %d bytes\n", len(plaintext))
+}
+
+func cmdNacEnroll() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enroll NAC-PREFIX CERT-FILE KEY-FILE",
+		Short: "Enroll for NAC access using NDNCERT-issued certificate",
+		Long: `Enroll as an authorized NAC consumer using your NDNCERT-issued certificate.
+
+This generates an X25519 encryption key pair, sends the public key along with
+your certificate to the NAC server's ENROLL endpoint, and saves the private key.
+
+The server verifies the certificate was signed by the CA, then authorizes your
+identity for encrypted content access.`,
+		Example: `  ndnd nac enroll /demo/nac client.cert client.key`,
+		Args:    cobra.ExactArgs(3),
+		Run:     runNacEnroll,
+	}
+}
+
+func runNacEnroll(_ *cobra.Command, args []string) {
+	nacPrefix := args[0]
+	certFile := args[1]
+	keyFile := args[2]
+
+	// Load NDNCERT-issued certificate
+	certFileBytes, err := os.ReadFile(certFile)
+	if err != nil {
+		log.Fatal(nil, "Failed to read cert file", "err", err)
+		return
+	}
+	_, certs, _ := sec.DecodeFile(certFileBytes)
+	if len(certs) != 1 {
+		log.Fatal(nil, "Cert file must contain exactly one certificate")
+		return
+	}
+
+	// Load signing key (to prove ownership — though we send the cert itself for verification)
+	keyFileBytes, err := os.ReadFile(keyFile)
+	if err != nil {
+		log.Fatal(nil, "Failed to read key file", "err", err)
+		return
+	}
+	keys, _, _ := sec.DecodeFile(keyFileBytes)
+	if len(keys) != 1 {
+		log.Fatal(nil, "Key file must contain exactly one key")
+		return
+	}
+	_ = keys[0] // signer available if needed in future
+
+	// Generate X25519 key pair for NAC encryption
+	x25519Priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		log.Fatal(nil, "Failed to generate X25519 key", "err", err)
+		return
+	}
+	x25519PubBytes := x25519Priv.PublicKey().Bytes()
+
+	fmt.Fprintf(os.Stderr, "Generated X25519 key pair\n")
+	fmt.Fprintf(os.Stderr, "  Public:  %s\n", hex.EncodeToString(x25519PubBytes))
+
+	// Build enrollment payload: [32-byte X25519 pubkey][certificate wire]
+	payload := make([]byte, 0, 32+len(certs[0]))
+	payload = append(payload, x25519PubBytes...)
+	payload = append(payload, certs[0]...)
+
+	// Start engine
+	eng := engine.NewBasicEngine(engine.NewDefaultFace())
+	if err := eng.Start(); err != nil {
+		log.Fatal(nil, "Engine start failed", "err", err)
+		return
+	}
+	defer eng.Stop()
+
+	// Send enrollment Interest to <nac-prefix>/ENROLL
+	enrollName, err := enc.NameFromStr(nacPrefix + "/ENROLL")
+	if err != nil {
+		log.Fatal(nil, "Invalid NAC prefix", "err", err)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Enrolling at %s...\n", enrollName)
+
+	interest, err := eng.Spec().MakeInterest(enrollName, &ndn.InterestConfig{
+		Lifetime: optional.Some(10 * time.Second),
+		Nonce:    utils.ConvertNonce(eng.Timer().Nonce()),
+	}, enc.Wire{payload}, nil)
+	if err != nil {
+		log.Fatal(nil, "Failed to make enrollment Interest", "err", err)
+		return
+	}
+
+	ch := make(chan ndn.ExpressCallbackArgs, 1)
+	eng.Express(interest, func(args ndn.ExpressCallbackArgs) { ch <- args })
+	result := <-ch
+
+	if result.Result != ndn.InterestResultData {
+		log.Fatal(nil, "Enrollment failed", "result", result.Result)
+		return
+	}
+
+	// Parse response
+	response := result.Data.Content().Join()
+	if len(response) < 3 || string(response[:3]) != "OK:" {
+		fmt.Fprintf(os.Stderr, "Enrollment rejected: %s\n", string(response))
+		os.Exit(1)
+		return
+	}
+
+	// Response: "OK:" + KEK pub (32 bytes) + KEK ID (16 bytes)
+	respBody := response[3:]
+	if len(respBody) < 48 {
+		log.Fatal(nil, "Invalid enrollment response (too short)")
+		return
+	}
+	kekPubBytes := respBody[:32]
+	kekID := respBody[32:48]
+
+	fmt.Fprintf(os.Stderr, "\nEnrollment successful!\n")
+	fmt.Fprintf(os.Stderr, "  KEK Public Key: %s\n", hex.EncodeToString(kekPubBytes))
+	fmt.Fprintf(os.Stderr, "  KEK ID: %s\n", hex.EncodeToString(kekID))
+	fmt.Fprintf(os.Stderr, "  NAC Private Key: %s\n", hex.EncodeToString(x25519Priv.Bytes()))
+	fmt.Fprintf(os.Stderr, "\nSave your NAC private key — you'll need it to decrypt content.\n")
+
+	// Print machine-readable output to stdout
+	fmt.Printf("NAC_PRIVATE=%s\n", hex.EncodeToString(x25519Priv.Bytes()))
+	fmt.Printf("NAC_PUBLIC=%s\n", hex.EncodeToString(x25519PubBytes))
+	fmt.Printf("KEK_PUBLIC=%s\n", hex.EncodeToString(kekPubBytes))
+	fmt.Printf("KEK_ID=%s\n", hex.EncodeToString(kekID))
 }

--- a/tools/nac.go
+++ b/tools/nac.go
@@ -96,7 +96,7 @@ func (ns *NacServer) runServe(_ *cobra.Command, args []string) {
 			log.Fatal(ns, "Invalid member spec", "spec", memberSpec, "err", err)
 			return
 		}
-		if err := ks.AccessManager().AddMember(consumerKeyName, pubKey); err != nil {
+		if err := ks.AddMember(consumerKeyName, pubKey); err != nil {
 			log.Fatal(ns, "Failed to add member", "member", consumerKeyName, "err", err)
 			return
 		}

--- a/tools/nac.go
+++ b/tools/nac.go
@@ -25,6 +25,7 @@ import (
 type NacServer struct {
 	flags struct {
 		members []string
+		dataset string
 	}
 }
 
@@ -38,19 +39,20 @@ func CmdNac() *cobra.Command {
 
 	ns := NacServer{}
 	serveCmd := &cobra.Command{
-		Use:   "serve CREDENTIAL-PREFIX",
+		Use:   "serve ACCESS-PREFIX",
 		Short: "Run NAC key server",
 		Long: `Run the NAC key server that serves KEK (public) and encrypted KDKs (per-consumer).
 
 Members are specified as consumer-key-name:hex-public-key pairs.
-The key server serves:
-  - KEK at <credential-prefix>/E-KEY/<key-id>  (public, any producer can fetch)
-  - KDK at <credential-prefix>/D-KEY/<key-id>/FOR/<consumer>  (authorized consumers only)`,
+The key server registers at <access-prefix>/NAC/<dataset> and serves:
+  - KEK at <access-prefix>/NAC/<dataset>/KEK/<key-id>
+  - KDK at <access-prefix>/NAC/<dataset>/KDK/<key-id>/ENCRYPTED-BY/<consumer>`,
 		Args:    cobra.ExactArgs(1),
 		Run:     ns.runServe,
-		Example: `  ndnd nac serve /alice/read/documents --member "/alice/KEY/abc123:0a1b2c..."`,
+		Example: `  ndnd nac serve /alice --dataset documents --member "/alice/KEY/abc123:0a1b2c..."`,
 	}
 	serveCmd.Flags().StringArrayVar(&ns.flags.members, "member", nil, "Authorized member as 'consumer-key-name:hex-x25519-pubkey'")
+	serveCmd.Flags().StringVar(&ns.flags.dataset, "dataset", "default", "Dataset name for NAC namespace scoping")
 	cmd.AddCommand(serveCmd)
 
 	cmd.AddCommand(cmdNacEncrypt())
@@ -65,9 +67,9 @@ func (ns *NacServer) String() string {
 }
 
 func (ns *NacServer) runServe(_ *cobra.Command, args []string) {
-	credPrefix := args[0]
+	accessPrefix := args[0]
+	dataset := ns.flags.dataset
 
-	// ctart NDN engine
 	app := engine.NewBasicEngine(engine.NewDefaultFace())
 	if err := app.Start(); err != nil {
 		log.Fatal(ns, "Unable to start engine", "err", err)
@@ -75,22 +77,19 @@ func (ns *NacServer) runServe(_ *cobra.Command, args []string) {
 	}
 	defer app.Stop()
 
-	// create a signer for signing Data packets
-	keyName, _ := enc.NameFromStr(credPrefix + "/KEY/nac-server")
+	keyName, _ := enc.NameFromStr(accessPrefix + "/KEY/nac-server")
 	signer, err := sig.KeygenEd25519(keyName)
 	if err != nil {
 		log.Fatal(ns, "Unable to generate signing key", "err", err)
 		return
 	}
 
-	// create key server
-	ks, err := nac.NewKeyServer(app, signer, credPrefix)
+	ks, err := nac.NewKeyServer(app, signer, accessPrefix, dataset)
 	if err != nil {
 		log.Fatal(ns, "Unable to create key server", "err", err)
 		return
 	}
 
-	// add members
 	for _, memberSpec := range ns.flags.members {
 		consumerKeyName, pubKey, err := parseMemberSpec(memberSpec)
 		if err != nil {
@@ -108,7 +107,7 @@ func (ns *NacServer) runServe(_ *cobra.Command, args []string) {
 	kekPubBytes, _ := nac.SerializePublicKey(kek.PublicKey)
 	fmt.Printf("KEK ID: %s\n", hex.EncodeToString(kek.ID))
 	fmt.Printf("KEK Public Key: %s\n", hex.EncodeToString(kekPubBytes))
-	fmt.Printf("KEK Name: %s\n", nac.KEKName(credPrefix, kek.ID))
+	fmt.Printf("KEK Name: %s\n", nac.KEKName(accessPrefix, dataset, kek.ID))
 
 	// start serving keys
 	if err := ks.Start(); err != nil {
@@ -148,22 +147,26 @@ func parseMemberSpec(spec string) (string, *ecdh.PublicKey, error) {
 }
 
 func cmdNacEncrypt() *cobra.Command {
-	return &cobra.Command{
-		Use:   "encrypt KEK-PUB-HEX CREDENTIAL-PREFIX DATA-PREFIX",
+	var dataset string
+	cmd := &cobra.Command{
+		Use:   "encrypt KEK-PUB-HEX ACCESS-PREFIX DATA-PREFIX",
 		Short: "Encrypt stdin with NAC",
 		Long: `Encrypt data from stdin using NAC.
 Outputs encrypted content, encrypted CK, and CK name to files.`,
 		Args: cobra.ExactArgs(3),
-		Run:  runNacEncrypt,
+		Run: func(cmd *cobra.Command, args []string) {
+			runNacEncrypt(cmd, args, dataset)
+		},
 	}
+	cmd.Flags().StringVar(&dataset, "dataset", "default", "Dataset name for NAC namespace scoping")
+	return cmd
 }
 
-func runNacEncrypt(_ *cobra.Command, args []string) {
+func runNacEncrypt(_ *cobra.Command, args []string, dataset string) {
 	pubKeyHex := args[0]
-	credPrefix := args[1]
+	accessPrefix := args[1]
 	dataPrefix := args[2]
 
-	// parse KEK public key
 	pubKeyBytes, err := hex.DecodeString(pubKeyHex)
 	if err != nil {
 		log.Fatal(nil, "Invalid KEK hex", "err", err)
@@ -176,9 +179,8 @@ func runNacEncrypt(_ *cobra.Command, args []string) {
 	}
 
 	kek := &nac.KeyEncryptionKey{PublicKey: pubKey}
-	encryptor := nac.NewEncryptor(dataPrefix, credPrefix, kek)
+	encryptor := nac.NewEncryptor(dataPrefix, accessPrefix, dataset, kek)
 
-	// read plaintext from stdin
 	plaintext, err := os.ReadFile("/dev/stdin")
 	if err != nil {
 		log.Fatal(nil, "Failed to read stdin", "err", err)
@@ -192,13 +194,10 @@ func runNacEncrypt(_ *cobra.Command, args []string) {
 		return
 	}
 
-	// write encrypted content
 	if err := os.WriteFile("enc-content.bin", encContent.EncryptedPayload, 0644); err != nil {
 		log.Fatal(nil, "Failed to write encrypted content", "err", err)
 		return
 	}
-
-	// write encrypted CK
 	if err := os.WriteFile("enc-ck.bin", encCK.EncryptedPayload, 0644); err != nil {
 		log.Fatal(nil, "Failed to write encrypted CK", "err", err)
 		return
@@ -206,8 +205,8 @@ func runNacEncrypt(_ *cobra.Command, args []string) {
 
 	fmt.Fprintf(os.Stderr, "Encrypted content: enc-content.bin (%d bytes)\n", len(encContent.EncryptedPayload))
 	fmt.Fprintf(os.Stderr, "Encrypted CK: enc-ck.bin (%d bytes)\n", len(encCK.EncryptedPayload))
-	fmt.Fprintf(os.Stderr, "Content name: %s\n", encContent.Name)
-	fmt.Fprintf(os.Stderr, "CK name: %s\n", encCK.Name)
+	fmt.Fprintf(os.Stderr, "CK name: %s\n", encContent.CKName)
+	fmt.Fprintf(os.Stderr, "CK encrypted name: %s\n", encCK.Name)
 }
 
 func cmdNacDecrypt() *cobra.Command {
@@ -272,26 +271,30 @@ func runNacDecrypt(_ *cobra.Command, args []string) {
 }
 
 func cmdNacEnroll() *cobra.Command {
-	return &cobra.Command{
-		Use:   "enroll NAC-PREFIX CERT-FILE KEY-FILE",
+	var dataset string
+	cmd := &cobra.Command{
+		Use:   "enroll ACCESS-PREFIX CERT-FILE KEY-FILE",
 		Short: "Enroll for NAC access using NDNCERT-issued certificate",
 		Long: `Enroll as an authorized NAC consumer using your NDNCERT-issued certificate.
 
-This generates an X25519 encryption key pair, sends the public key along with
-your certificate to the NAC server's ENROLL endpoint, and saves the private key.
-
-The server verifies the certificate was signed by the CA, then authorizes your
-identity for encrypted content access.`,
-		Example: `  ndnd nac enroll /demo/nac client.cert client.key`,
+Sends enrollment Interest to <access-prefix>/NAC/<dataset>/ENROLL with X25519
+public key and certificate. Server verifies cert was CA-signed, then authorizes
+the consumer for encrypted content access.`,
+		Example: `  ndnd nac enroll /demo --dataset sensor-data client.cert client.key`,
 		Args:    cobra.ExactArgs(3),
-		Run:     runNacEnroll,
+		Run: func(cmd *cobra.Command, args []string) {
+			runNacEnroll(cmd, args, dataset)
+		},
 	}
+	cmd.Flags().StringVar(&dataset, "dataset", "default", "Dataset name for NAC namespace scoping")
+	return cmd
 }
 
-func runNacEnroll(_ *cobra.Command, args []string) {
-	nacPrefix := args[0]
+func runNacEnroll(_ *cobra.Command, args []string, dataset string) {
+	accessPrefix := args[0]
 	certFile := args[1]
 	keyFile := args[2]
+	nacPrefix := accessPrefix + "/NAC/" + dataset
 
 	// Load NDNCERT-issued certificate
 	certFileBytes, err := os.ReadFile(certFile)

--- a/tools/nac.go
+++ b/tools/nac.go
@@ -1,0 +1,263 @@
+package tools
+
+import (
+	"crypto/ecdh"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	enc "github.com/named-data/ndnd/std/encoding"
+	"github.com/named-data/ndnd/std/engine"
+	"github.com/named-data/ndnd/std/log"
+	"github.com/named-data/ndnd/std/nac"
+	sig "github.com/named-data/ndnd/std/security/signer"
+	"github.com/spf13/cobra"
+)
+
+type NacServer struct {
+	flags struct {
+		members []string
+	}
+}
+
+// CmdNac creates the nac command group
+func CmdNac() *cobra.Command {
+	cmd := &cobra.Command{
+		GroupID: "tools",
+		Use:     "nac",
+		Short:   "Name-based Access Control (NAC) tools",
+	}
+
+	ns := NacServer{}
+	serveCmd := &cobra.Command{
+		Use:   "serve CREDENTIAL-PREFIX",
+		Short: "Run NAC key server",
+		Long: `Run the NAC key server that serves KEK (public) and encrypted KDKs (per-consumer).
+
+Members are specified as consumer-key-name:hex-public-key pairs.
+The key server serves:
+  - KEK at <credential-prefix>/E-KEY/<key-id>  (public, any producer can fetch)
+  - KDK at <credential-prefix>/D-KEY/<key-id>/FOR/<consumer>  (authorized consumers only)`,
+		Args:    cobra.ExactArgs(1),
+		Run:     ns.runServe,
+		Example: `  ndnd nac serve /alice/read/documents --member "/alice/KEY/abc123:0a1b2c..."`,
+	}
+	serveCmd.Flags().StringArrayVar(&ns.flags.members, "member", nil, "Authorized member as 'consumer-key-name:hex-x25519-pubkey'")
+	cmd.AddCommand(serveCmd)
+
+	cmd.AddCommand(cmdNacEncrypt())
+	cmd.AddCommand(cmdNacDecrypt())
+
+	return cmd
+}
+
+func (ns *NacServer) String() string {
+	return "nac-server"
+}
+
+func (ns *NacServer) runServe(_ *cobra.Command, args []string) {
+	credPrefix := args[0]
+
+	// ctart NDN engine
+	app := engine.NewBasicEngine(engine.NewDefaultFace())
+	if err := app.Start(); err != nil {
+		log.Fatal(ns, "Unable to start engine", "err", err)
+		return
+	}
+	defer app.Stop()
+
+	// create a signer for signing Data packets
+	keyName, _ := enc.NameFromStr(credPrefix + "/KEY/nac-server")
+	signer, err := sig.KeygenEd25519(keyName)
+	if err != nil {
+		log.Fatal(ns, "Unable to generate signing key", "err", err)
+		return
+	}
+
+	// create key server
+	ks, err := nac.NewKeyServer(app, signer, credPrefix)
+	if err != nil {
+		log.Fatal(ns, "Unable to create key server", "err", err)
+		return
+	}
+
+	// add members
+	for _, memberSpec := range ns.flags.members {
+		consumerKeyName, pubKey, err := parseMemberSpec(memberSpec)
+		if err != nil {
+			log.Fatal(ns, "Invalid member spec", "spec", memberSpec, "err", err)
+			return
+		}
+		if err := ks.AccessManager().AddMember(consumerKeyName, pubKey); err != nil {
+			log.Fatal(ns, "Failed to add member", "member", consumerKeyName, "err", err)
+			return
+		}
+		fmt.Printf("Added authorized member: %s\n", consumerKeyName)
+	}
+
+	kek := ks.AccessManager().KEK()
+	fmt.Printf("KEK ID: %s\n", hex.EncodeToString(kek.ID))
+	fmt.Printf("KEK Name: %s\n", nac.KEKName(credPrefix, kek.ID))
+
+	// start serving keys
+	if err := ks.Start(); err != nil {
+		log.Fatal(ns, "Unable to start key server", "err", err)
+		return
+	}
+	defer ks.Stop()
+
+	// wait for signal
+	sigchan := make(chan os.Signal, 1)
+	signal.Notify(sigchan, os.Interrupt, syscall.SIGTERM)
+	<-sigchan
+	log.Info(nil, "Shutting down NAC key server")
+}
+
+func parseMemberSpec(spec string) (string, *ecdh.PublicKey, error) {
+	// format: consumer-key-name:hex-x25519-pubkey
+	for i := len(spec) - 1; i >= 0; i-- {
+		if spec[i] == ':' {
+			keyName := spec[:i]
+			pubKeyHex := spec[i+1:]
+
+			pubKeyBytes, err := hex.DecodeString(pubKeyHex)
+			if err != nil {
+				return "", nil, fmt.Errorf("invalid hex public key: %w", err)
+			}
+
+			pubKey, err := nac.DeserializePublicKey(pubKeyBytes)
+			if err != nil {
+				return "", nil, fmt.Errorf("invalid X25519 public key: %w", err)
+			}
+
+			return keyName, pubKey, nil
+		}
+	}
+	return "", nil, fmt.Errorf("expected format 'consumer-key-name:hex-x25519-pubkey'")
+}
+
+func cmdNacEncrypt() *cobra.Command {
+	return &cobra.Command{
+		Use:   "encrypt KEK-PUB-HEX CREDENTIAL-PREFIX DATA-PREFIX",
+		Short: "Encrypt stdin with NAC",
+		Long: `Encrypt data from stdin using NAC.
+Outputs encrypted content, encrypted CK, and CK name to files.`,
+		Args: cobra.ExactArgs(3),
+		Run:  runNacEncrypt,
+	}
+}
+
+func runNacEncrypt(_ *cobra.Command, args []string) {
+	pubKeyHex := args[0]
+	credPrefix := args[1]
+	dataPrefix := args[2]
+
+	// parse KEK public key
+	pubKeyBytes, err := hex.DecodeString(pubKeyHex)
+	if err != nil {
+		log.Fatal(nil, "Invalid KEK hex", "err", err)
+		return
+	}
+	pubKey, err := nac.DeserializePublicKey(pubKeyBytes)
+	if err != nil {
+		log.Fatal(nil, "Invalid X25519 public key", "err", err)
+		return
+	}
+
+	kek := &nac.KeyEncryptionKey{PublicKey: pubKey}
+	encryptor := nac.NewEncryptor(dataPrefix, credPrefix, kek)
+
+	// read plaintext from stdin
+	plaintext, err := os.ReadFile("/dev/stdin")
+	if err != nil {
+		log.Fatal(nil, "Failed to read stdin", "err", err)
+		return
+	}
+
+	contentName := dataPrefix + "/data"
+	encContent, encCK, err := encryptor.Encrypt(contentName, plaintext)
+	if err != nil {
+		log.Fatal(nil, "Encryption failed", "err", err)
+		return
+	}
+
+	// write encrypted content
+	if err := os.WriteFile("enc-content.bin", encContent.EncryptedPayload, 0644); err != nil {
+		log.Fatal(nil, "Failed to write encrypted content", "err", err)
+		return
+	}
+
+	// write encrypted CK
+	if err := os.WriteFile("enc-ck.bin", encCK.EncryptedPayload, 0644); err != nil {
+		log.Fatal(nil, "Failed to write encrypted CK", "err", err)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Encrypted content: enc-content.bin (%d bytes)\n", len(encContent.EncryptedPayload))
+	fmt.Fprintf(os.Stderr, "Encrypted CK: enc-ck.bin (%d bytes)\n", len(encCK.EncryptedPayload))
+	fmt.Fprintf(os.Stderr, "Content name: %s\n", encContent.Name)
+	fmt.Fprintf(os.Stderr, "CK name: %s\n", encCK.Name)
+}
+
+func cmdNacDecrypt() *cobra.Command {
+	return &cobra.Command{
+		Use:   "decrypt PRIVATE-KEY-HEX CONSUMER-KEY-NAME ENC-KDK-FILE ENC-CK-FILE ENC-CONTENT-FILE",
+		Short: "Decrypt NAC-encrypted data",
+		Long:  `Decrypt NAC-encrypted data using consumer's private key and the encrypted KDK/CK/content files.`,
+		Args:  cobra.ExactArgs(5),
+		Run:   runNacDecrypt,
+	}
+}
+
+func runNacDecrypt(_ *cobra.Command, args []string) {
+	privKeyHex := args[0]
+	consumerKeyName := args[1]
+	encKDKFile := args[2]
+	encCKFile := args[3]
+	encContentFile := args[4]
+
+	// parse private key
+	privKeyBytes, err := hex.DecodeString(privKeyHex)
+	if err != nil {
+		log.Fatal(nil, "Invalid private key hex", "err", err)
+		return
+	}
+	privKey, err := nac.DeserializePrivateKey(privKeyBytes)
+	if err != nil {
+		log.Fatal(nil, "Invalid X25519 private key", "err", err)
+		return
+	}
+
+	// read encrypted files
+	encKDK, err := os.ReadFile(encKDKFile)
+	if err != nil {
+		log.Fatal(nil, "Failed to read encrypted KDK", "err", err)
+		return
+	}
+	encCKPayload, err := os.ReadFile(encCKFile)
+	if err != nil {
+		log.Fatal(nil, "Failed to read encrypted CK", "err", err)
+		return
+	}
+	encContentPayload, err := os.ReadFile(encContentFile)
+	if err != nil {
+		log.Fatal(nil, "Failed to read encrypted content", "err", err)
+		return
+	}
+
+	decryptor := nac.NewDecryptor(consumerKeyName, privKey)
+	plaintext, err := decryptor.Decrypt(
+		&nac.EncryptedContent{EncryptedPayload: encContentPayload},
+		&nac.EncryptedCK{EncryptedPayload: encCKPayload},
+		encKDK,
+	)
+	if err != nil {
+		log.Fatal(nil, "Decryption failed", "err", err)
+		return
+	}
+
+	os.Stdout.Write(plaintext)
+	fmt.Fprintf(os.Stderr, "Decrypted %d bytes\n", len(plaintext))
+}

--- a/tools/putchunks.go
+++ b/tools/putchunks.go
@@ -18,9 +18,10 @@ import (
 )
 
 type PutChunks struct {
-	expose  bool
-	nacKek  string // hex KEK public key
-	nacCred string // NAC credential prefix
+	expose     bool
+	nacKek     string // hex KEK public key
+	nacAccess  string // NAC access prefix
+	nacDataset string // NAC dataset name
 }
 
 // (AI GENERATED DESCRIPTION): Creates a Cobra command that publishes data chunks read from standard input under a specified name prefix, optionally registering the prefix with the client origin.
@@ -40,7 +41,8 @@ This tool expects data from the standard input.`,
 
 	cmd.Flags().BoolVar(&pc.expose, "expose", false, "Use client origin for prefix registration")
 	cmd.Flags().StringVar(&pc.nacKek, "nac-kek", "", "NAC KEK public key (hex) for encryption")
-	cmd.Flags().StringVar(&pc.nacCred, "nac-cred", "", "NAC credential prefix (required with --nac-kek)")
+	cmd.Flags().StringVar(&pc.nacAccess, "nac-access", "", "NAC access prefix (required with --nac-kek)")
+	cmd.Flags().StringVar(&pc.nacDataset, "nac-dataset", "default", "NAC dataset name")
 	return cmd
 }
 
@@ -91,8 +93,8 @@ func (pc *PutChunks) run(_ *cobra.Command, args []string) {
 	// If NAC encryption is enabled, encrypt the content before publishing
 	var encCKContent enc.Wire
 	if pc.nacKek != "" {
-		if pc.nacCred == "" {
-			log.Fatal(pc, "--nac-cred is required when using --nac-kek")
+		if pc.nacAccess == "" {
+			log.Fatal(pc, "--nac-access is required when using --nac-kek")
 			return
 		}
 
@@ -108,8 +110,8 @@ func (pc *PutChunks) run(_ *cobra.Command, args []string) {
 		}
 
 		kek := &nac.KeyEncryptionKey{PublicKey: pubKey, ID: make([]byte, 16)}
-		copy(kek.ID, kekBytes[:16]) // use first 16 bytes of pubkey as ID for naming
-		encryptor := nac.NewEncryptor(args[0], pc.nacCred, kek)
+		copy(kek.ID, kekBytes[:16])
+		encryptor := nac.NewEncryptor(args[0], pc.nacAccess, pc.nacDataset, kek)
 
 		encContent, encCK, err := encryptor.Encrypt(args[0]+"/data", content.Join())
 		if err != nil {

--- a/tools/putchunks.go
+++ b/tools/putchunks.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/hex"
 	"io"
 	"os"
 	"os/signal"
@@ -9,6 +10,7 @@ import (
 	enc "github.com/named-data/ndnd/std/encoding"
 	"github.com/named-data/ndnd/std/engine"
 	"github.com/named-data/ndnd/std/log"
+	"github.com/named-data/ndnd/std/nac"
 	"github.com/named-data/ndnd/std/ndn"
 	"github.com/named-data/ndnd/std/object"
 	"github.com/named-data/ndnd/std/object/storage"
@@ -16,7 +18,9 @@ import (
 )
 
 type PutChunks struct {
-	expose bool
+	expose  bool
+	nacKek  string // hex KEK public key
+	nacCred string // NAC credential prefix
 }
 
 // (AI GENERATED DESCRIPTION): Creates a Cobra command that publishes data chunks read from standard input under a specified name prefix, optionally registering the prefix with the client origin.
@@ -35,6 +39,8 @@ This tool expects data from the standard input.`,
 	}
 
 	cmd.Flags().BoolVar(&pc.expose, "expose", false, "Use client origin for prefix registration")
+	cmd.Flags().StringVar(&pc.nacKek, "nac-kek", "", "NAC KEK public key (hex) for encryption")
+	cmd.Flags().StringVar(&pc.nacCred, "nac-cred", "", "NAC credential prefix (required with --nac-kek)")
 	return cmd
 }
 
@@ -82,6 +88,42 @@ func (pc *PutChunks) run(_ *cobra.Command, args []string) {
 		}
 	}
 
+	// If NAC encryption is enabled, encrypt the content before publishing
+	var encCKContent enc.Wire
+	if pc.nacKek != "" {
+		if pc.nacCred == "" {
+			log.Fatal(pc, "--nac-cred is required when using --nac-kek")
+			return
+		}
+
+		kekBytes, err := hex.DecodeString(pc.nacKek)
+		if err != nil {
+			log.Fatal(pc, "Invalid KEK hex", "err", err)
+			return
+		}
+		pubKey, err := nac.DeserializePublicKey(kekBytes)
+		if err != nil {
+			log.Fatal(pc, "Invalid KEK public key", "err", err)
+			return
+		}
+
+		kek := &nac.KeyEncryptionKey{PublicKey: pubKey, ID: make([]byte, 16)}
+		copy(kek.ID, kekBytes[:16]) // use first 16 bytes of pubkey as ID for naming
+		encryptor := nac.NewEncryptor(args[0], pc.nacCred, kek)
+
+		encContent, encCK, err := encryptor.Encrypt(args[0]+"/data", content.Join())
+		if err != nil {
+			log.Fatal(pc, "NAC encryption failed", "err", err)
+			return
+		}
+
+		content = enc.Wire{encContent.EncryptedPayload}
+		encCKContent = enc.Wire{encCK.EncryptedPayload}
+		log.Info(pc, "Content encrypted with NAC",
+			"content_bytes", len(encContent.EncryptedPayload),
+			"ck_bytes", len(encCK.EncryptedPayload))
+	}
+
 	// produce object
 	vname, err := cli.Produce(ndn.ProduceArgs{
 		Name:    name.WithVersion(enc.VersionUnixMicro),
@@ -90,6 +132,20 @@ func (pc *PutChunks) run(_ *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(pc, "Unable to produce object", "err", err)
 		return
+	}
+
+	// If NAC, also publish the encrypted CK under <prefix>/CK
+	if encCKContent != nil {
+		ckName := name.Append(enc.NewGenericComponent("CK"))
+		_, err := cli.Produce(ndn.ProduceArgs{
+			Name:    ckName.WithVersion(enc.VersionUnixMicro),
+			Content: encCKContent,
+		})
+		if err != nil {
+			log.Fatal(pc, "Unable to produce encrypted CK", "err", err)
+			return
+		}
+		log.Info(pc, "Encrypted CK published", "name", ckName)
 	}
 
 	content = nil // gc

--- a/tools/sec/cert_server.go
+++ b/tools/sec/cert_server.go
@@ -89,10 +89,7 @@ func (c *CertServer) run(_ *cobra.Command, args []string) {
 
 	if c.mockDNS {
 		log.Warn(c, "Mock DNS enabled -- do not use in production")
-		caServer.DNSResolver = func(domain string) ([]string, error) {
-			log.Debug(c, "mock dns", "domain", domain)
-			return []string{"mock-token-any"}, nil
-		}
+		caServer.MockDNS = true
 	}
 
 	if err := caServer.Start(); err != nil {

--- a/tools/sec/cert_server.go
+++ b/tools/sec/cert_server.go
@@ -1,0 +1,118 @@
+package sec
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	enc "github.com/named-data/ndnd/std/encoding"
+	"github.com/named-data/ndnd/std/engine"
+	"github.com/named-data/ndnd/std/log"
+	sec "github.com/named-data/ndnd/std/security"
+	"github.com/named-data/ndnd/std/security/ndncert/server"
+	"github.com/spf13/cobra"
+)
+
+type CertServer struct {
+	mockDNS bool
+}
+
+func CmdCertServer() *cobra.Command {
+	srv := CertServer{}
+
+	cmd := &cobra.Command{
+		GroupID: "sec",
+		Use:     "certca CA-CONFIG CA-CERT CA-KEY",
+		Short:   "NDNCERT Certificate Authority Server",
+		Args:    cobra.ExactArgs(3),
+		Run:     srv.run,
+	}
+
+	cmd.Flags().BoolVar(&srv.mockDNS, "mock-dns", false,
+		"Mock DNS lookups (testing only)")
+
+	return cmd
+}
+
+func (c *CertServer) String() string { return "ndncert-ca" }
+
+func (c *CertServer) run(_ *cobra.Command, args []string) {
+	configFile, certFile, keyFile := args[0], args[1], args[2]
+
+	config, err := server.LoadConfig(configFile)
+	if err != nil {
+		log.Fatal(c, "Bad config", "err", err)
+		return
+	}
+	config.CaCertPath = certFile
+	config.CaKeyPath = keyFile
+
+	// load cert
+	certBytes, err := os.ReadFile(certFile)
+	if err != nil {
+		log.Fatal(c, "Can't read cert", "err", err)
+		return
+	}
+	_, caCerts, _ := sec.DecodeFile(certBytes)
+	if len(caCerts) != 1 {
+		log.Fatal(c, "Need exactly one cert in file")
+		return
+	}
+
+	// load key
+	keyBytes, err := os.ReadFile(keyFile)
+	if err != nil {
+		log.Fatal(c, "Can't read key", "err", err)
+		return
+	}
+	keys, _, _ := sec.DecodeFile(keyBytes)
+	if len(keys) != 1 {
+		log.Fatal(c, "Need exactly one key in file")
+		return
+	}
+
+	// engine
+	ndnEngine := engine.NewBasicEngine(engine.NewDefaultFace())
+	if err := ndnEngine.Start(); err != nil {
+		log.Fatal(c, "Engine start failed", "err", err)
+		return
+	}
+	defer ndnEngine.Stop()
+
+	// ca server
+	caServer, err := server.NewCaServer(ndnEngine, config, enc.Wire{caCerts[0]}, keys[0])
+	if err != nil {
+		log.Fatal(c, "Failed to create CA", "err", err)
+		return
+	}
+
+	if c.mockDNS {
+		log.Warn(c, "Mock DNS enabled -- do not use in production")
+		caServer.DNSResolver = func(domain string) ([]string, error) {
+			log.Debug(c, "mock dns", "domain", domain)
+			return []string{"mock-token-any"}, nil
+		}
+	}
+
+	if err := caServer.Start(); err != nil {
+		log.Fatal(c, "CA start failed", "err", err)
+		return
+	}
+	defer caServer.Stop()
+
+	fmt.Fprintf(os.Stderr, "\nNDNCERT CA running: %s\n", config.CaPrefix)
+	for _, ch := range config.SupportedChallenges {
+		fmt.Fprintf(os.Stderr, "  challenge: %s\n", ch.Name)
+	}
+	if c.mockDNS {
+		fmt.Fprintf(os.Stderr, "  *** mock DNS enabled ***\n")
+	}
+	fmt.Fprintf(os.Stderr, "\nCtrl+C to stop\n\n")
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	<-sig
+
+	log.Info(c, "Shutting down")
+}

--- a/tools/sec/cert_server.go
+++ b/tools/sec/cert_server.go
@@ -20,6 +20,7 @@ import (
 type CertServer struct {
 	mockDNS    bool
 	nacPrefix  string
+	nacDataset string
 }
 
 func CmdCertServer() *cobra.Command {
@@ -36,7 +37,9 @@ func CmdCertServer() *cobra.Command {
 	cmd.Flags().BoolVar(&srv.mockDNS, "mock-dns", false,
 		"Mock DNS lookups (testing only)")
 	cmd.Flags().StringVar(&srv.nacPrefix, "nac", "",
-		"Enable NAC key server at this credential prefix (e.g., /demo/nac)")
+		"Enable NAC key server at this access prefix (e.g., /demo)")
+	cmd.Flags().StringVar(&srv.nacDataset, "nac-dataset", "default",
+		"NAC dataset name for namespace scoping")
 
 	return cmd
 }
@@ -121,13 +124,12 @@ func (c *CertServer) run(_ *cobra.Command, args []string) {
 			return
 		}
 
-		nacServer, err := nac.NewKeyServer(ndnEngine, nacSigner, c.nacPrefix)
+		nacServer, err := nac.NewKeyServer(ndnEngine, nacSigner, c.nacPrefix, c.nacDataset)
 		if err != nil {
 			log.Fatal(c, "Failed to create NAC server", "err", err)
 			return
 		}
 
-		// Register CA cert so enrollment can verify client certificates
 		caCertData, _, err := spec.Spec{}.ReadData(enc.NewBufferView(caCerts[0]))
 		if err != nil {
 			log.Fatal(c, "Failed to parse CA cert for NAC", "err", err)
@@ -143,10 +145,11 @@ func (c *CertServer) run(_ *cobra.Command, args []string) {
 
 		kek := nacServer.AccessManager().KEK()
 		kekPubBytes, _ := nac.SerializePublicKey(kek.PublicKey)
-		fmt.Fprintf(os.Stderr, "\nNAC key server running: %s\n", c.nacPrefix)
+		nacNs := c.nacPrefix + "/NAC/" + c.nacDataset
+		fmt.Fprintf(os.Stderr, "\nNAC key server running: %s\n", nacNs)
 		fmt.Fprintf(os.Stderr, "  KEK ID: %x\n", kek.ID)
 		fmt.Fprintf(os.Stderr, "  KEK Public Key: %x\n", kekPubBytes)
-		fmt.Fprintf(os.Stderr, "  Enrollment: %s/ENROLL\n", c.nacPrefix)
+		fmt.Fprintf(os.Stderr, "  Enrollment: %s/ENROLL\n", nacNs)
 	}
 
 	fmt.Fprintf(os.Stderr, "\nCtrl+C to stop\n\n")

--- a/tools/sec/cert_server.go
+++ b/tools/sec/cert_server.go
@@ -9,13 +9,17 @@ import (
 	enc "github.com/named-data/ndnd/std/encoding"
 	"github.com/named-data/ndnd/std/engine"
 	"github.com/named-data/ndnd/std/log"
+	"github.com/named-data/ndnd/std/nac"
 	sec "github.com/named-data/ndnd/std/security"
 	"github.com/named-data/ndnd/std/security/ndncert/server"
+	sig "github.com/named-data/ndnd/std/security/signer"
+	spec "github.com/named-data/ndnd/std/ndn/spec_2022"
 	"github.com/spf13/cobra"
 )
 
 type CertServer struct {
-	mockDNS bool
+	mockDNS    bool
+	nacPrefix  string
 }
 
 func CmdCertServer() *cobra.Command {
@@ -31,6 +35,8 @@ func CmdCertServer() *cobra.Command {
 
 	cmd.Flags().BoolVar(&srv.mockDNS, "mock-dns", false,
 		"Mock DNS lookups (testing only)")
+	cmd.Flags().StringVar(&srv.nacPrefix, "nac", "",
+		"Enable NAC key server at this credential prefix (e.g., /demo/nac)")
 
 	return cmd
 }
@@ -105,11 +111,49 @@ func (c *CertServer) run(_ *cobra.Command, args []string) {
 	if c.mockDNS {
 		fmt.Fprintf(os.Stderr, "  *** mock DNS enabled ***\n")
 	}
+
+	// Start NAC key server if --nac is set
+	if c.nacPrefix != "" {
+		nacKeyName, _ := enc.NameFromStr(c.nacPrefix + "/KEY/nac-server")
+		nacSigner, err := sig.KeygenEd25519(nacKeyName)
+		if err != nil {
+			log.Fatal(c, "Failed to generate NAC signer", "err", err)
+			return
+		}
+
+		nacServer, err := nac.NewKeyServer(ndnEngine, nacSigner, c.nacPrefix)
+		if err != nil {
+			log.Fatal(c, "Failed to create NAC server", "err", err)
+			return
+		}
+
+		// Register CA cert so enrollment can verify client certificates
+		caCertData, _, err := spec.Spec{}.ReadData(enc.NewBufferView(caCerts[0]))
+		if err != nil {
+			log.Fatal(c, "Failed to parse CA cert for NAC", "err", err)
+			return
+		}
+		nacServer.RegisterCACert(caCertData)
+
+		if err := nacServer.Start(); err != nil {
+			log.Fatal(c, "NAC server start failed", "err", err)
+			return
+		}
+		defer nacServer.Stop()
+
+		kek := nacServer.AccessManager().KEK()
+		kekPubBytes, _ := nac.SerializePublicKey(kek.PublicKey)
+		fmt.Fprintf(os.Stderr, "\nNAC key server running: %s\n", c.nacPrefix)
+		fmt.Fprintf(os.Stderr, "  KEK ID: %x\n", kek.ID)
+		fmt.Fprintf(os.Stderr, "  KEK Public Key: %x\n", kekPubBytes)
+		fmt.Fprintf(os.Stderr, "  Enrollment: %s/ENROLL\n", c.nacPrefix)
+	}
+
 	fmt.Fprintf(os.Stderr, "\nCtrl+C to stop\n\n")
 
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
-	<-sig
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	<-sigChan
 
 	log.Info(c, "Shutting down")
 }


### PR DESCRIPTION
- **adding config parser for ndn cert v0.3 configs and example config**
- **add the ca handlers and states to track in map**
- **ndncert dns challenge implementation. adheres to NDNCERT Protocol 0.3 spec**
- **ndncert + nac integration: DNS challenge, MockDNS, NAC key server and CLI - NDNCERT: added a MockDNS bypass for demo/testing, challenge selection from client request - NAC: added key server with interest handlers (KEK public, KDK per-consumer) - NAC: added consumer client for fetching keys over NDN - NAC: added cli commands (ndnd nac serve/encrypt/decrypt)**
- **nac: core crypto library - x25519 ecies, aes-gcm, access manager**
- **nac: enrollment endpoint + consumer interest fixes**
- **certca: integrate nac server via --nac flag**
- **put/cat: nac encrypt and decrypt integration**
- **nac: adopt spec naming - NAC/<dataset>/KEK|KDK, /ENCRYPTED-BY/**
- **nac: pre-produce signed KEK/KDK data packets, serve from store**
