### PR TITLE
sync: include 'v=3' in sync prefix announcement

### DIFF
--- a/std/examples/svs/passive/main.go
+++ b/std/examples/svs/passive/main.go
@@ -66,8 +66,8 @@ func main() {
 	})
 
 	// Announce group prefix route
-	client.AnnouncePrefix(ndn.Announcement{Name: group})
-	defer client.WithdrawPrefix(group, nil)
+	client.AnnouncePrefix(ndn.Announcement{Name: svsync.SyncPrefix()})
+	defer client.WithdrawPrefix(svsync.SyncPrefix(), nil)
 
 	err = svsync.Start()
 	if err != nil {

--- a/std/examples/svs/pure-sync/main.go
+++ b/std/examples/svs/pure-sync/main.go
@@ -64,8 +64,8 @@ func main() {
 	})
 
 	// Announce group prefix route
-	client.AnnouncePrefix(ndn.Announcement{Name: group})
-	defer client.WithdrawPrefix(group, nil)
+	client.AnnouncePrefix(ndn.Announcement{Name: svsync.SyncPrefix()})
+	defer client.WithdrawPrefix(svsync.SyncPrefix(), nil)
 
 	err = svsync.Start()
 	if err != nil {

--- a/std/sync/svs.go
+++ b/std/sync/svs.go
@@ -156,6 +156,12 @@ func (s *SvSync) String() string {
 	return fmt.Sprintf("svs (%s)", s.o.GroupPrefix)
 }
 
+// SyncPrefix is the sync route prefix for this instance.
+// It should be used in the prefix registration / announcement.
+func (s *SvSync) SyncPrefix() enc.Name {
+	return s.prefix
+}
+
 // Start the SV Sync instance.
 func (s *SvSync) Start() (err error) {
 	err = s.o.Client.Engine().AttachHandler(s.prefix,

--- a/std/sync/svs_alo.go
+++ b/std/sync/svs_alo.go
@@ -163,7 +163,7 @@ func (s *SvsALO) GroupPrefix() enc.Name {
 
 // SyncPrefix is the sync route prefix for this instance.
 func (s *SvsALO) SyncPrefix() enc.Name {
-	return s.opts.Svs.GroupPrefix
+	return s.svs.SyncPrefix()
 }
 
 // DataPrefix is the data route prefix for this instance.

--- a/std/sync/svs_test.go
+++ b/std/sync/svs_test.go
@@ -1,0 +1,99 @@
+package sync
+
+import (
+	"testing"
+
+	enc "github.com/named-data/ndnd/std/encoding"
+	"github.com/named-data/ndnd/std/ndn"
+	tu "github.com/named-data/ndnd/std/utils/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockClient is a stub implementation of the Client interface.
+type MockClient struct{}
+
+func (m *MockClient) String() string {
+	return "mock-client"
+}
+
+func (m *MockClient) Start() error {
+	return nil
+}
+
+func (m *MockClient) Stop() error {
+	return nil
+}
+
+func (m *MockClient) Engine() ndn.Engine {
+	return nil
+}
+
+func (m *MockClient) Store() ndn.Store {
+	return nil
+}
+
+func (m *MockClient) Produce(args ndn.ProduceArgs) (enc.Name, error) {
+	return nil, nil
+}
+
+func (m *MockClient) Remove(name enc.Name) error {
+	return nil
+}
+
+func (m *MockClient) Consume(name enc.Name, callback func(status ndn.ConsumeState)) {
+}
+
+func (m *MockClient) ConsumeExt(args ndn.ConsumeExtArgs) {}
+
+func (m *MockClient) LatestLocal(name enc.Name) (enc.Name, error) {
+	return nil, nil
+}
+
+func (m *MockClient) GetLocal(name enc.Name) (enc.Wire, error) {
+	return nil, nil
+}
+
+func (m *MockClient) ExpressR(args ndn.ExpressRArgs) {}
+
+func (m *MockClient) IsCongested() bool {
+	return false
+}
+
+func (m *MockClient) SuggestSigner(name enc.Name) ndn.Signer {
+	return nil
+}
+
+func (m *MockClient) Validate(data ndn.Data, sigCov enc.Wire, callback func(bool, error)) {}
+
+func (m *MockClient) ValidateExt(args ndn.ValidateExtArgs) {}
+
+func (m *MockClient) SetTrustSchema(schema ndn.TrustSchema) {}
+
+func (m *MockClient) PromoteTrustAnchor(cert ndn.Data, raw enc.Wire) {}
+
+func (m *MockClient) AnnouncePrefix(args ndn.Announcement) {}
+
+func (m *MockClient) WithdrawPrefix(name enc.Name, onError func(error)) {}
+
+func (m *MockClient) AttachCommandHandler(name enc.Name, handler func(name enc.Name, content enc.Wire, reply func(enc.Wire) error)) error {
+	return nil
+}
+
+func (m *MockClient) DetachCommandHandler(name enc.Name) error {
+	return nil
+}
+
+func (m *MockClient) ExpressCommand(dest enc.Name, name enc.Name, cmd enc.Wire, callback func(enc.Wire, error)) {
+}
+
+func TestSvSync_SyncPrefix(t *testing.T) {
+	tu.SetT(t)
+
+	sv := NewSvSync(SvSyncOpts{
+		Client:      &MockClient{},
+		GroupPrefix: tu.NoErr(enc.NameFromStr("/G")),
+		OnUpdate:    func(ssu SvSyncUpdate) {},
+	})
+
+	assert.True(t, sv.SyncPrefix().Equal(tu.NoErr(enc.NameFromStr("/G/v=3"))))
+}


### PR DESCRIPTION
Spec change: https://github.com/named-data/StateVectorSync/pull/21